### PR TITLE
feat: add create_folder tool

### DIFF
--- a/src/tools/create-folder.ts
+++ b/src/tools/create-folder.ts
@@ -1,0 +1,31 @@
+import { TFolder } from 'obsidian';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type McpPlugin from '../main';
+import type { StatsTracker } from '../stats';
+import type { McpLogger } from '../logging';
+import { ACCESS_DENIED_MSG, WRITE_ANNOTATIONS } from './constants';
+
+export function registerCreateFolder(mcp: McpServer, plugin: McpPlugin, tracker: StatsTracker, logger: McpLogger): void {
+    mcp.registerTool('create_folder', {
+        description: 'Create a new folder at the specified path. Creates intermediate folders if needed (like mkdir -p).',
+        annotations: WRITE_ANNOTATIONS,
+        inputSchema: {
+            path: z.string().describe("Vault-relative folder path (e.g. 'Projects/SerialMan/Research')"),
+        },
+    }, tracker.track('create_folder', async ({ path }) => {
+        if (!plugin.security.isAllowed(path)) {
+            logger.warning('create_folder: access denied', { path });
+            return { content: [{ type: 'text', text: ACCESS_DENIED_MSG }], isError: true };
+        }
+        const existing = plugin.app.vault.getAbstractFileByPath(path);
+        if (existing instanceof TFolder) {
+            return { content: [{ type: 'text', text: `Folder already exists at ${path}` }] };
+        }
+        if (existing) {
+            return { content: [{ type: 'text', text: `A file already exists at ${path}` }], isError: true };
+        }
+        await plugin.app.vault.createFolder(path);
+        return { content: [{ type: 'text', text: `Created folder ${path}` }] };
+    }));
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,6 +15,7 @@ import { registerGetNoteMetadata } from './get-note-metadata';
 import { registerListRecentNotes } from './list-recent-notes';
 import { registerSearchContent } from './search-content';
 import { registerListSessions } from './list-sessions';
+import { registerCreateFolder } from './create-folder';
 
 export function registerTools(mcp: McpServer, plugin: McpPlugin, logger: McpLogger): void {
     const tracker = plugin.statsTracker;
@@ -32,4 +33,5 @@ export function registerTools(mcp: McpServer, plugin: McpPlugin, logger: McpLogg
     registerListRecentNotes(mcp, plugin, tracker, logger);
     registerSearchContent(mcp, plugin, tracker, logger);
     registerListSessions(mcp, plugin, tracker, logger);
+    registerCreateFolder(mcp, plugin, tracker, logger);
 }

--- a/tests/tools/create-folder.test.ts
+++ b/tests/tools/create-folder.test.ts
@@ -1,0 +1,65 @@
+import { TFile, TFolder } from 'obsidian';
+import { registerCreateFolder } from '../../src/tools/create-folder';
+
+describe('create_folder tool', () => {
+    let handler: (args: any, extra: any) => Promise<any>;
+    const mockMcp = {
+        registerTool: jest.fn((_name, _opts, fn) => { handler = fn; }),
+    };
+    const mockPlugin = {
+        app: {
+            vault: {
+                getAbstractFileByPath: jest.fn(),
+                createFolder: jest.fn().mockResolvedValue(undefined),
+            },
+            metadataCache: {
+                getFileCache: jest.fn(() => null),
+            },
+        },
+        security: {
+            isAllowed: jest.fn().mockReturnValue(true),
+        },
+    };
+    const mockTracker = { track: (_name: string, fn: any) => fn };
+    const mockLogger = { info: jest.fn(), warning: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(null);
+        mockPlugin.security.isAllowed.mockReturnValue(true);
+        registerCreateFolder(mockMcp as any, mockPlugin as any, mockTracker as any, mockLogger as any);
+    });
+
+    test('creates a new folder', async () => {
+        const result = await handler({ path: 'Projects/New' }, { sessionId: 's1' });
+        expect(mockPlugin.app.vault.createFolder).toHaveBeenCalledWith('Projects/New');
+        expect(result.content[0].text).toContain('Created folder');
+    });
+
+    test('returns success message when folder already exists', async () => {
+        const folder = new TFolder();
+        folder.path = 'Projects/Existing';
+        mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(folder);
+        const result = await handler({ path: 'Projects/Existing' }, { sessionId: 's1' });
+        expect(mockPlugin.app.vault.createFolder).not.toHaveBeenCalled();
+        expect(result.content[0].text).toContain('already exists');
+        expect(result.isError).toBeUndefined();
+    });
+
+    test('returns error when a file exists at the path', async () => {
+        const file = new TFile();
+        file.path = 'Projects/file.md';
+        mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(file);
+        const result = await handler({ path: 'Projects/file.md' }, { sessionId: 's1' });
+        expect(mockPlugin.app.vault.createFolder).not.toHaveBeenCalled();
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('file already exists');
+    });
+
+    test('returns error when path is access-denied', async () => {
+        mockPlugin.security.isAllowed.mockReturnValue(false);
+        const result = await handler({ path: 'Secret/folder' }, { sessionId: 's1' });
+        expect(result.isError).toBe(true);
+        expect(mockPlugin.app.vault.createFolder).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `create_folder` MCP tool for creating vault directories
- Supports nested creation (like `mkdir -p`) via Obsidian's `vault.createFolder()`
- Returns success if folder already exists (idempotent)
- Returns error if a file exists at the path (prevents overwrite)
- Enforces access control rules

Closes #24

## Test plan

- [x] 4 unit tests covering creation, already exists, file conflict, access denial
- [x] Build passes