### PR TITLE
feat: add patch_note tool for find-and-replace editing

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,7 @@ import { registerListSessions } from './list-sessions';
 import { registerGetBacklinks } from './get-backlinks';
 import { registerAppendNote } from './append-note';
 import { registerCreateFolder } from './create-folder';
+import { registerPatchNote } from './patch-note';
 
 export function registerTools(mcp: McpServer, plugin: McpPlugin, logger: McpLogger): void {
     const tracker = plugin.statsTracker;
@@ -38,4 +39,5 @@ export function registerTools(mcp: McpServer, plugin: McpPlugin, logger: McpLogg
     registerGetBacklinks(mcp, plugin, tracker, logger);
     registerAppendNote(mcp, plugin, tracker, logger);
     registerCreateFolder(mcp, plugin, tracker, logger);
+    registerPatchNote(mcp, plugin, tracker, logger);
 }

--- a/src/tools/patch-note.ts
+++ b/src/tools/patch-note.ts
@@ -1,0 +1,50 @@
+import { TFile } from 'obsidian';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type McpPlugin from '../main';
+import type { StatsTracker } from '../stats';
+import type { McpLogger } from '../logging';
+import { ACCESS_DENIED_MSG, MAX_EDIT_LENGTH, WRITE_IDEMPOTENT_ANNOTATIONS } from './constants';
+
+export function registerPatchNote(mcp: McpServer, plugin: McpPlugin, tracker: StatsTracker, logger: McpLogger): void {
+    mcp.registerTool('patch_note', {
+        description: 'Perform a find-and-replace edit on a note. Replaces the first occurrence of old_string with new_string without rewriting the entire note.',
+        annotations: WRITE_IDEMPOTENT_ANNOTATIONS,
+        inputSchema: {
+            path: z.string().describe("Vault-relative path (e.g. 'Notes/project.md')"),
+            old_string: z.string().min(1).describe('Exact text to find in the note'),
+            new_string: z.string()
+                .max(MAX_EDIT_LENGTH, `Replacement exceeds maximum length of ${MAX_EDIT_LENGTH} characters`)
+                .describe('Text to replace it with'),
+        },
+    }, tracker.track('patch_note', async ({ path, old_string, new_string }) => {
+        if (!plugin.security.isAllowed(path)) {
+            logger.warning('patch_note: access denied', { path });
+            return { content: [{ type: 'text', text: ACCESS_DENIED_MSG }], isError: true };
+        }
+        const file = plugin.app.vault.getAbstractFileByPath(path);
+        if (!(file instanceof TFile)) {
+            return { content: [{ type: 'text', text: ACCESS_DENIED_MSG }], isError: true };
+        }
+        if (!plugin.security.isAllowed(file)) {
+            logger.warning('patch_note: access denied by tag rule', { path });
+            return { content: [{ type: 'text', text: ACCESS_DENIED_MSG }], isError: true };
+        }
+
+        const content = await plugin.app.vault.read(file);
+
+        const firstIndex = content.indexOf(old_string);
+        if (firstIndex === -1) {
+            return { content: [{ type: 'text', text: `old_string not found in ${path}` }], isError: true };
+        }
+
+        const secondIndex = content.indexOf(old_string, firstIndex + old_string.length);
+        if (secondIndex !== -1) {
+            return { content: [{ type: 'text', text: `old_string matches multiple locations in ${path}. Provide more context to make the match unique.` }], isError: true };
+        }
+
+        const newContent = content.substring(0, firstIndex) + new_string + content.substring(firstIndex + old_string.length);
+        await plugin.app.vault.modify(file, newContent);
+        return { content: [{ type: 'text', text: `Patched ${path}` }] };
+    }));
+}

--- a/tests/tools/patch-note.test.ts
+++ b/tests/tools/patch-note.test.ts
@@ -1,0 +1,101 @@
+import { TFile } from 'obsidian';
+import { registerPatchNote } from '../../src/tools/patch-note';
+
+describe('patch_note tool', () => {
+    let handler: (args: any, extra: any) => Promise<any>;
+    const mockMcp = {
+        registerTool: jest.fn((_name, _opts, fn) => { handler = fn; }),
+    };
+    const mockFile = Object.assign(new TFile(), {
+        path: 'Notes/project.md',
+        name: 'project.md',
+        stat: { mtime: 1000, ctime: 900, size: 200 },
+    });
+    const mockPlugin = {
+        app: {
+            vault: {
+                getAbstractFileByPath: jest.fn(() => mockFile),
+                read: jest.fn(),
+                modify: jest.fn().mockResolvedValue(undefined),
+            },
+            metadataCache: { getFileCache: jest.fn(() => null) },
+        },
+        security: { isAllowed: jest.fn().mockReturnValue(true) },
+    };
+    const mockTracker = { track: (_name: string, fn: any) => fn };
+    const mockLogger = { info: jest.fn(), warning: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockPlugin.security.isAllowed.mockReturnValue(true);
+        mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(mockFile);
+        registerPatchNote(mockMcp as any, mockPlugin as any, mockTracker as any, mockLogger as any);
+    });
+
+    test('replaces a unique match', async () => {
+        mockPlugin.app.vault.read.mockResolvedValue('status: draft\ntitle: My Note');
+        const result = await handler(
+            { path: 'Notes/project.md', old_string: 'status: draft', new_string: 'status: published' },
+            { sessionId: 's1' }
+        );
+        expect(mockPlugin.app.vault.modify).toHaveBeenCalledWith(
+            mockFile,
+            'status: published\ntitle: My Note'
+        );
+        expect(result.content[0].text).toContain('Patched');
+    });
+
+    test('returns error when old_string not found', async () => {
+        mockPlugin.app.vault.read.mockResolvedValue('some content');
+        const result = await handler(
+            { path: 'Notes/project.md', old_string: 'nonexistent', new_string: 'replacement' },
+            { sessionId: 's1' }
+        );
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('not found');
+        expect(mockPlugin.app.vault.modify).not.toHaveBeenCalled();
+    });
+
+    test('returns error when old_string matches multiple locations', async () => {
+        mockPlugin.app.vault.read.mockResolvedValue('foo bar foo baz');
+        const result = await handler(
+            { path: 'Notes/project.md', old_string: 'foo', new_string: 'qux' },
+            { sessionId: 's1' }
+        );
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('multiple locations');
+        expect(mockPlugin.app.vault.modify).not.toHaveBeenCalled();
+    });
+
+    test('returns error when path is access-denied', async () => {
+        mockPlugin.security.isAllowed.mockReturnValue(false);
+        const result = await handler(
+            { path: 'Secret/note.md', old_string: 'a', new_string: 'b' },
+            { sessionId: 's1' }
+        );
+        expect(result.isError).toBe(true);
+        expect(mockPlugin.app.vault.modify).not.toHaveBeenCalled();
+    });
+
+    test('returns error when file does not exist', async () => {
+        mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(null);
+        const result = await handler(
+            { path: 'Missing.md', old_string: 'a', new_string: 'b' },
+            { sessionId: 's1' }
+        );
+        expect(result.isError).toBe(true);
+    });
+
+    test('handles replacement that deletes content (empty new_string)', async () => {
+        mockPlugin.app.vault.read.mockResolvedValue('keep this remove-me keep that');
+        const result = await handler(
+            { path: 'Notes/project.md', old_string: ' remove-me', new_string: '' },
+            { sessionId: 's1' }
+        );
+        expect(mockPlugin.app.vault.modify).toHaveBeenCalledWith(
+            mockFile,
+            'keep this keep that'
+        );
+        expect(result.content[0].text).toContain('Patched');
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `patch_note` MCP tool for surgical find-and-replace edits
- Replaces first occurrence of `old_string` with `new_string`
- Fails if `old_string` not found (no silent no-ops)
- Fails if `old_string` matches multiple locations (requires unique match)
- Supports empty `new_string` for deletion
- Enforces access control and max content length

Closes #27

## Test plan

- [x] 6 unit tests: unique match, not found, multiple matches, access denied, missing file, empty replacement
- [x] Build passes