### PR TITLE
feat: add frontmatter filter to search_notes

### DIFF
--- a/src/tools/search-notes.ts
+++ b/src/tools/search-notes.ts
@@ -19,15 +19,16 @@ const outputSchema = {
 
 export function registerSearchNotes(mcp: McpServer, plugin: McpPlugin, tracker: StatsTracker, logger: McpLogger): void {
     mcp.registerTool('search_notes', {
-        description: 'Search for notes by time range and tags. Returns a list of file paths.',
+        description: 'Search for notes by time range, tags, and/or frontmatter fields. Returns a list of file paths.',
         annotations: READ_ONLY_ANNOTATIONS,
         outputSchema,
         inputSchema: {
             start_date: z.string().optional().describe('ISO date string (YYYY-MM-DD). Filter notes modified after this date.'),
             end_date: z.string().optional().describe('ISO date string. Filter notes modified before this date.'),
             tags: z.array(z.string()).optional().describe("List of tags to filter by (e.g. ['#work'])"),
+            frontmatter: z.record(z.string()).optional().describe("Filter by frontmatter fields (e.g. {\"status\": \"draft\", \"priority\": \"high\"}). All fields must match (AND logic)."),
         },
-    }, tracker.track('search_notes', async ({ start_date, end_date, tags }) => {
+    }, tracker.track('search_notes', async ({ start_date, end_date, tags, frontmatter }) => {
         let files = plugin.app.vault.getFiles();
         files = files.filter(f => plugin.security.isAllowed(f));
 
@@ -46,6 +47,17 @@ export function registerSearchNotes(mcp: McpServer, plugin: McpPlugin, tracker: 
                 const fileTags = getTagsFromCache(cache);
                 return tags.every(requiredTag =>
                     fileTags.some(ft => ft.startsWith(requiredTag)),
+                );
+            });
+        }
+
+        if (frontmatter && Object.keys(frontmatter).length > 0) {
+            files = files.filter(f => {
+                const cache = plugin.app.metadataCache.getFileCache(f);
+                const fm = cache?.frontmatter;
+                if (!fm) return false;
+                return Object.entries(frontmatter).every(([key, value]) =>
+                    String(fm[key] ?? '') === value,
                 );
             });
         }

--- a/tests/tools/search-notes-frontmatter.test.ts
+++ b/tests/tools/search-notes-frontmatter.test.ts
@@ -1,0 +1,112 @@
+import { TFile } from 'obsidian';
+
+jest.mock('moment', () => {
+    const m = (val: any) => ({ format: () => String(val), valueOf: () => val });
+    m.default = m;
+    return m;
+});
+
+import { registerSearchNotes } from '../../src/tools/search-notes';
+
+describe('search_notes frontmatter filter', () => {
+    let handler: (args: any, extra: any) => Promise<any>;
+    const mockMcp = {
+        registerTool: jest.fn((_name, _opts, fn) => { handler = fn; }),
+    };
+
+    const makeFile = (path: string, mtime: number) => {
+        return Object.assign(new TFile(), {
+            path,
+            name: path.split('/').pop(),
+            extension: 'md',
+            stat: { mtime, ctime: mtime - 100, size: 100 },
+        });
+    };
+
+    const fileA = makeFile('Notes/draft.md', 1000);
+    const fileB = makeFile('Notes/published.md', 2000);
+    const fileC = makeFile('Notes/nofront.md', 3000);
+
+    const caches: Record<string, any> = {
+        'Notes/draft.md': { frontmatter: { status: 'draft', priority: 'high' } },
+        'Notes/published.md': { frontmatter: { status: 'published', priority: 'low' } },
+        'Notes/nofront.md': null,
+    };
+
+    const mockPlugin = {
+        app: {
+            vault: {
+                getFiles: jest.fn(() => [fileA, fileB, fileC]),
+            },
+            metadataCache: {
+                getFileCache: jest.fn((f: any) => caches[f.path] ?? null),
+            },
+        },
+        security: { isAllowed: jest.fn().mockReturnValue(true) },
+    };
+    const mockTracker = { track: (_name: string, fn: any) => fn };
+    const mockLogger = { info: jest.fn(), warning: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockPlugin.security.isAllowed.mockReturnValue(true);
+        registerSearchNotes(mockMcp as any, mockPlugin as any, mockTracker as any, mockLogger as any);
+    });
+
+    test('no frontmatter filter returns all files', async () => {
+        const result = await handler({}, { sessionId: 's1' });
+        expect(result.structuredContent.results).toHaveLength(3);
+    });
+
+    test('filters by single frontmatter field', async () => {
+        const result = await handler({ frontmatter: { status: 'draft' } }, { sessionId: 's1' });
+        expect(result.structuredContent.results).toHaveLength(1);
+        expect(result.structuredContent.results[0].path).toBe('Notes/draft.md');
+    });
+
+    test('filters by multiple frontmatter fields (AND logic)', async () => {
+        const result = await handler(
+            { frontmatter: { status: 'draft', priority: 'high' } },
+            { sessionId: 's1' }
+        );
+        expect(result.structuredContent.results).toHaveLength(1);
+        expect(result.structuredContent.results[0].path).toBe('Notes/draft.md');
+    });
+
+    test('returns empty when no notes match frontmatter', async () => {
+        const result = await handler(
+            { frontmatter: { status: 'draft', priority: 'low' } },
+            { sessionId: 's1' }
+        );
+        expect(result.structuredContent.results).toHaveLength(0);
+    });
+
+    test('excludes files with no frontmatter', async () => {
+        const result = await handler(
+            { frontmatter: { status: 'published' } },
+            { sessionId: 's1' }
+        );
+        expect(result.structuredContent.results).toHaveLength(1);
+        expect(result.structuredContent.results[0].path).toBe('Notes/published.md');
+    });
+
+    test('combines frontmatter with tags filter', async () => {
+        // Add tags to cache
+        caches['Notes/draft.md'] = {
+            frontmatter: { status: 'draft', priority: 'high' },
+            tags: [{ tag: '#work' }],
+        };
+        caches['Notes/published.md'] = {
+            frontmatter: { status: 'published', priority: 'low' },
+            tags: [{ tag: '#personal' }],
+        };
+        registerSearchNotes(mockMcp as any, mockPlugin as any, mockTracker as any, mockLogger as any);
+
+        const result = await handler(
+            { tags: ['#work'], frontmatter: { status: 'draft' } },
+            { sessionId: 's1' }
+        );
+        expect(result.structuredContent.results).toHaveLength(1);
+        expect(result.structuredContent.results[0].path).toBe('Notes/draft.md');
+    });
+});


### PR DESCRIPTION
## Summary

- Adds optional `frontmatter: Record<string, string>` parameter to `search_notes`
- Filters notes whose frontmatter fields match all specified key-value pairs (AND logic)
- Values compared as strings via `String(fm[key])`
- Combines with existing `tags`, `start_date`, `end_date` filters
- Notes without frontmatter are excluded when filter is active

Closes #31

## Test plan

- [x] 6 unit tests: no filter, single field, multiple fields, no match, no frontmatter exclusion, combined with tags
- [x] Build passes