### PR TITLE
feat: add sorting, filtering, and recursion to list_folder

### DIFF
--- a/src/tools/list-folder.ts
+++ b/src/tools/list-folder.ts
@@ -1,4 +1,4 @@
-import { TFolder } from 'obsidian';
+import { TFile, TFolder } from 'obsidian';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type McpPlugin from '../main';
@@ -15,15 +15,43 @@ const outputSchema = {
     })),
 };
 
+function collectChildren(
+    folder: TFolder,
+    security: { isAllowed: (p: string) => boolean },
+    recursive: boolean,
+    maxDepth: number,
+    currentDepth: number,
+): FileInfo[] {
+    const items: FileInfo[] = [];
+    for (const child of folder.children) {
+        if (!security.isAllowed(child.path)) continue;
+        const isFolder = child instanceof TFolder;
+        items.push({
+            name: child.name,
+            path: child.path,
+            type: isFolder ? 'folder' as const : 'file' as const,
+        });
+        if (recursive && isFolder && currentDepth < maxDepth) {
+            items.push(...collectChildren(child as TFolder, security, recursive, maxDepth, currentDepth + 1));
+        }
+    }
+    return items;
+}
+
 export function registerListFolder(mcp: McpServer, plugin: McpPlugin, tracker: StatsTracker, logger: McpLogger): void {
     mcp.registerTool('list_folder', {
-        description: 'List files and folders inside a specific directory.',
+        description: 'List files and folders inside a specific directory. Supports sorting, file type filtering, and recursive listing.',
         annotations: READ_ONLY_ANNOTATIONS,
         outputSchema,
         inputSchema: {
             path: z.string().default('/').describe('Directory path (default: root)'),
+            sort_by: z.enum(['name', 'modified', 'created', 'size']).optional().describe('Sort results by this field'),
+            sort_order: z.enum(['asc', 'desc']).default('asc').describe('Sort direction (default: asc)'),
+            file_types: z.array(z.string()).optional().describe("Filter to files with these extensions (e.g. ['.md']). Folders are always included."),
+            recursive: z.boolean().default(false).describe('List contents of subdirectories recursively'),
+            depth: z.number().int().min(1).optional().describe('Max recursion depth (only when recursive=true). Default: unlimited.'),
         },
-    }, tracker.track('list_folder', async ({ path }) => {
+    }, tracker.track('list_folder', async ({ path, sort_by, sort_order, file_types, recursive, depth }) => {
         if (!plugin.security.isAllowed(path)) {
             logger.warning('list_folder: access denied', { path });
             return { content: [{ type: 'text' as const, text: ACCESS_DENIED_MSG }], isError: true };
@@ -34,16 +62,44 @@ export function registerListFolder(mcp: McpServer, plugin: McpPlugin, tracker: S
         if (!(folder instanceof TFolder)) {
             return { content: [{ type: 'text' as const, text: ACCESS_DENIED_MSG }], isError: true };
         }
-        const children: FileInfo[] = folder.children
-            .filter(c => plugin.security.isAllowed(c.path))
-            .map(c => ({
-                name: c.name,
-                path: c.path,
-                type: c instanceof TFolder ? 'folder' as const : 'file' as const,
-            }));
+
+        const maxDepth = recursive ? (depth ?? Infinity) : 1;
+        let items = collectChildren(folder, plugin.security, recursive, maxDepth, 1);
+
+        // Filter by file types (folders always pass)
+        if (file_types && file_types.length > 0) {
+            items = items.filter(item =>
+                item.type === 'folder' || file_types.some(ext => item.name.endsWith(ext)),
+            );
+        }
+
+        // Sort
+        if (sort_by) {
+            items.sort((a, b) => {
+                let cmp = 0;
+                if (sort_by === 'name') {
+                    cmp = a.name.localeCompare(b.name);
+                } else {
+                    // For modified/created/size, look up file stats
+                    const aFile = plugin.app.vault.getAbstractFileByPath(a.path);
+                    const bFile = plugin.app.vault.getAbstractFileByPath(b.path);
+                    const aStat = aFile instanceof TFile ? aFile.stat : null;
+                    const bStat = bFile instanceof TFile ? bFile.stat : null;
+                    if (sort_by === 'modified') {
+                        cmp = (aStat?.mtime ?? 0) - (bStat?.mtime ?? 0);
+                    } else if (sort_by === 'created') {
+                        cmp = (aStat?.ctime ?? 0) - (bStat?.ctime ?? 0);
+                    } else if (sort_by === 'size') {
+                        cmp = (aStat?.size ?? 0) - (bStat?.size ?? 0);
+                    }
+                }
+                return sort_order === 'desc' ? -cmp : cmp;
+            });
+        }
+
         return {
-            structuredContent: { items: children },
-            content: [{ type: 'text' as const, text: JSON.stringify(children, null, 2) }],
+            structuredContent: { items },
+            content: [{ type: 'text' as const, text: JSON.stringify(items, null, 2) }],
         };
     }));
 }

--- a/tests/tools/list-folder.test.ts
+++ b/tests/tools/list-folder.test.ts
@@ -1,0 +1,149 @@
+import { TFile, TFolder } from 'obsidian';
+import { registerListFolder } from '../../src/tools/list-folder';
+
+describe('list_folder tool', () => {
+    let handler: (args: any, extra: any) => Promise<any>;
+    const mockMcp = {
+        registerTool: jest.fn((_name, _opts, fn) => { handler = fn; }),
+    };
+
+    const makeFile = (path: string, mtime: number, size: number) => {
+        const f = Object.assign(new TFile(), {
+            path,
+            name: path.split('/').pop(),
+            extension: path.split('.').pop() ?? '',
+            stat: { mtime, ctime: mtime - 100, size },
+        });
+        return f;
+    };
+
+    const makeFolder = (path: string, children: any[] = []) => {
+        const f = Object.assign(new TFolder(), {
+            path,
+            name: path.split('/').pop() || path,
+            children,
+        });
+        return f;
+    };
+
+    // Build a folder hierarchy:
+    // Projects/
+    //   alpha/
+    //     notes.md (mtime: 3000, size: 500)
+    //     data.csv (mtime: 1000, size: 200)
+    //   beta.md (mtime: 2000, size: 300)
+    //   readme.txt (mtime: 4000, size: 100)
+
+    const alphaNotesFile = makeFile('Projects/alpha/notes.md', 3000, 500);
+    const alphaDataFile = makeFile('Projects/alpha/data.csv', 1000, 200);
+    const alphaFolder = makeFolder('Projects/alpha', [alphaNotesFile, alphaDataFile]);
+    const betaFile = makeFile('Projects/beta.md', 2000, 300);
+    const readmeFile = makeFile('Projects/readme.txt', 4000, 100);
+    const projectsFolder = makeFolder('Projects', [alphaFolder, betaFile, readmeFile]);
+
+    const mockPlugin = {
+        app: {
+            vault: {
+                getRoot: jest.fn(),
+                getAbstractFileByPath: jest.fn((p: string) => {
+                    if (p === 'Projects') return projectsFolder;
+                    if (p === 'Projects/alpha') return alphaFolder;
+                    return null;
+                }),
+            },
+            metadataCache: { getFileCache: jest.fn(() => null) },
+        },
+        security: { isAllowed: jest.fn().mockReturnValue(true) },
+    };
+    const mockTracker = { track: (_name: string, fn: any) => fn };
+    const mockLogger = { info: jest.fn(), warning: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockPlugin.security.isAllowed.mockReturnValue(true);
+        mockPlugin.app.vault.getAbstractFileByPath.mockImplementation((p: string) => {
+            if (p === 'Projects') return projectsFolder;
+            if (p === 'Projects/alpha') return alphaFolder;
+            if (p === 'Projects/alpha/notes.md') return alphaNotesFile;
+            if (p === 'Projects/alpha/data.csv') return alphaDataFile;
+            if (p === 'Projects/beta.md') return betaFile;
+            if (p === 'Projects/readme.txt') return readmeFile;
+            return null;
+        });
+        registerListFolder(mockMcp as any, mockPlugin as any, mockTracker as any, mockLogger as any);
+    });
+
+    test('lists immediate children (default behavior)', async () => {
+        const result = await handler({ path: 'Projects' }, { sessionId: 's1' });
+        const items = result.structuredContent.items;
+        expect(items).toHaveLength(3);
+        expect(items.map((i: any) => i.name)).toEqual(expect.arrayContaining(['alpha', 'beta.md', 'readme.txt']));
+    });
+
+    test('sort_by name ascending', async () => {
+        const result = await handler({ path: 'Projects', sort_by: 'name', sort_order: 'asc' }, { sessionId: 's1' });
+        const names = result.structuredContent.items.map((i: any) => i.name);
+        expect(names).toEqual(['alpha', 'beta.md', 'readme.txt']);
+    });
+
+    test('sort_by name descending', async () => {
+        const result = await handler({ path: 'Projects', sort_by: 'name', sort_order: 'desc' }, { sessionId: 's1' });
+        const names = result.structuredContent.items.map((i: any) => i.name);
+        expect(names).toEqual(['readme.txt', 'beta.md', 'alpha']);
+    });
+
+    test('sort_by modified descending', async () => {
+        const result = await handler({ path: 'Projects', sort_by: 'modified', sort_order: 'desc' }, { sessionId: 's1' });
+        const names = result.structuredContent.items.map((i: any) => i.name);
+        // readme.txt (4000) > alpha (folder, no mtime → 0) > beta.md (2000)
+        // Folders have no stat, so they sort to end when sorting by modified desc
+        expect(names[0]).toBe('readme.txt');
+        expect(names[1]).toBe('beta.md');
+    });
+
+    test('filter by file_types', async () => {
+        const result = await handler({ path: 'Projects', file_types: ['.md'] }, { sessionId: 's1' });
+        const items = result.structuredContent.items;
+        // Should include beta.md and alpha folder (folders always included)
+        const fileItems = items.filter((i: any) => i.type === 'file');
+        expect(fileItems).toHaveLength(1);
+        expect(fileItems[0].name).toBe('beta.md');
+        // Folders are always included
+        expect(items.some((i: any) => i.type === 'folder')).toBe(true);
+    });
+
+    test('recursive listing', async () => {
+        const result = await handler({ path: 'Projects', recursive: true }, { sessionId: 's1' });
+        const items = result.structuredContent.items;
+        // Should include: alpha/ folder, beta.md, readme.txt, alpha/notes.md, alpha/data.csv
+        expect(items).toHaveLength(5);
+        expect(items.map((i: any) => i.path)).toEqual(expect.arrayContaining([
+            'Projects/alpha',
+            'Projects/beta.md',
+            'Projects/readme.txt',
+            'Projects/alpha/notes.md',
+            'Projects/alpha/data.csv',
+        ]));
+    });
+
+    test('recursive with depth limit', async () => {
+        const result = await handler({ path: 'Projects', recursive: true, depth: 1 }, { sessionId: 's1' });
+        const items = result.structuredContent.items;
+        // depth=1 means immediate children only (same as non-recursive)
+        expect(items).toHaveLength(3);
+    });
+
+    test('recursive with file_types filter', async () => {
+        const result = await handler({ path: 'Projects', recursive: true, file_types: ['.md'] }, { sessionId: 's1' });
+        const items = result.structuredContent.items;
+        const files = items.filter((i: any) => i.type === 'file');
+        expect(files.every((f: any) => f.name.endsWith('.md'))).toBe(true);
+        expect(files).toHaveLength(2); // beta.md and alpha/notes.md
+    });
+
+    test('access denied returns error', async () => {
+        mockPlugin.security.isAllowed.mockReturnValue(false);
+        const result = await handler({ path: 'Secret' }, { sessionId: 's1' });
+        expect(result.isError).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `sort_by` param: `name`, `modified`, `created`, `size` with `sort_order` (`asc`/`desc`)
- Adds `file_types` param: filter to specific extensions (e.g. `[".md"]`), folders always included
- Adds `recursive` param: list contents of subdirectories
- Adds `depth` param: limit recursion depth (only when `recursive=true`)
- All parameters are optional — fully backward-compatible

## Test plan
- [x] Default behavior unchanged (immediate children listed)
- [x] Sort by name ascending/descending
- [x] Sort by modified descending (folders with no stat sort to end)
- [x] Filter by file_types (folders always pass through)
- [x] Recursive listing includes nested children
- [x] Recursive with depth limit
- [x] Recursive combined with file_types filter
- [x] Access denied returns error
- [x] Full test suite passes (103 tests, 15 suites)

Closes #42