### PR TITLE
feat: add read_attachment and add_attachment MCP tools

### DIFF
--- a/src/tools/add-attachment.ts
+++ b/src/tools/add-attachment.ts
@@ -1,0 +1,51 @@
+import { TFolder } from 'obsidian';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type McpPlugin from '../main';
+import type { StatsTracker } from '../stats';
+import type { McpLogger } from '../logging';
+import { ACCESS_DENIED_MSG, MAX_ATTACHMENT_SIZE, WRITE_ANNOTATIONS } from './constants';
+
+export function registerAddAttachment(mcp: McpServer, plugin: McpPlugin, tracker: StatsTracker, logger: McpLogger): void {
+    mcp.registerTool('add_attachment', {
+        description: 'Save a binary attachment (image, PDF, etc.) to the vault from base64-encoded data. Returns the vault-relative path for embedding as ![[path]].',
+        annotations: WRITE_ANNOTATIONS,
+        inputSchema: {
+            filename: z.string().describe("Filename with extension (e.g. 'diagram.png')"),
+            data: z.string().describe('Base64-encoded file content'),
+            folder: z.string().optional().describe("Optional vault folder to save into (e.g. 'Attachments'). If omitted, uses Obsidian's configured attachment folder."),
+        },
+    }, tracker.track('add_attachment', async ({ filename, data, folder }) => {
+        if (data.length > MAX_ATTACHMENT_SIZE) {
+            return {
+                content: [{ type: 'text', text: `Attachment data exceeds maximum size of ${MAX_ATTACHMENT_SIZE} bytes` }],
+                isError: true,
+            };
+        }
+        let targetPath: string;
+        if (folder) {
+            if (!plugin.security.isAllowed(folder)) {
+                logger.warning('add_attachment: folder access denied', { folder });
+                return { content: [{ type: 'text', text: ACCESS_DENIED_MSG }], isError: true };
+            }
+            const existing = plugin.app.vault.getAbstractFileByPath(folder);
+            if (!(existing instanceof TFolder)) {
+                try {
+                    await plugin.app.vault.createFolder(folder);
+                } catch {
+                    // folder may already exist or be created concurrently
+                }
+            }
+            targetPath = `${folder}/${filename}`;
+        } else {
+            targetPath = (plugin.app as any).fileManager.getAvailablePathForAttachment(filename);
+        }
+        if (!plugin.security.isAllowed(targetPath)) {
+            logger.warning('add_attachment: target path access denied', { targetPath });
+            return { content: [{ type: 'text', text: ACCESS_DENIED_MSG }], isError: true };
+        }
+        const buffer = Buffer.from(data, 'base64');
+        await plugin.app.vault.createBinary(targetPath, buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength));
+        return { content: [{ type: 'text', text: `Created attachment at ${targetPath}` }] };
+    }));
+}

--- a/src/tools/constants.ts
+++ b/src/tools/constants.ts
@@ -10,6 +10,7 @@ export const MAX_SNIPPET_LENGTH = 200;
 export const MAX_RECENT_NOTES = 50;
 export const MAX_BACKLINKS = 50;
 export const MAX_BACKLINK_CONTEXT_LENGTH = 200;
+export const MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024; // 10MB base64 input limit
 export const STATS_SAVE_DEBOUNCE_MS = 5000;
 
 export const READ_ONLY_ANNOTATIONS: ToolAnnotations = {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -20,6 +20,8 @@ import { registerAppendNote } from './append-note';
 import { registerCreateFolder } from './create-folder';
 import { registerRenameNote } from './rename-note';
 import { registerPatchNote } from './patch-note';
+import { registerReadAttachment } from './read-attachment';
+import { registerAddAttachment } from './add-attachment';
 
 export function registerTools(mcp: McpServer, plugin: McpPlugin, logger: McpLogger): void {
     const tracker = plugin.statsTracker;
@@ -42,4 +44,6 @@ export function registerTools(mcp: McpServer, plugin: McpPlugin, logger: McpLogg
     registerCreateFolder(mcp, plugin, tracker, logger);
     registerRenameNote(mcp, plugin, tracker, logger);
     registerPatchNote(mcp, plugin, tracker, logger);
+    registerReadAttachment(mcp, plugin, tracker, logger);
+    registerAddAttachment(mcp, plugin, tracker, logger);
 }

--- a/src/tools/read-attachment.ts
+++ b/src/tools/read-attachment.ts
@@ -1,0 +1,52 @@
+import { TFile } from 'obsidian';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type McpPlugin from '../main';
+import type { StatsTracker } from '../stats';
+import type { McpLogger } from '../logging';
+import { getMimeType, isImageMime } from '../utils';
+import { ACCESS_DENIED_MSG, READ_ONLY_ANNOTATIONS } from './constants';
+
+export function registerReadAttachment(mcp: McpServer, plugin: McpPlugin, tracker: StatsTracker, logger: McpLogger): void {
+    mcp.registerTool('read_attachment', {
+        description: 'Read a binary attachment (image, PDF, etc.) from the vault. Images are returned as base64 image content that AI models can see. Non-image files return metadata only.',
+        annotations: READ_ONLY_ANNOTATIONS,
+        inputSchema: {
+            path: z.string().describe("Vault-relative path to the attachment (e.g. 'Attachments/diagram.png')"),
+        },
+    }, tracker.track('read_attachment', async ({ path }) => {
+        if (!plugin.security.isAllowed(path)) {
+            logger.warning('read_attachment: access denied', { path });
+            return { content: [{ type: 'text', text: ACCESS_DENIED_MSG }], isError: true };
+        }
+        const file = plugin.app.vault.getAbstractFileByPath(path);
+        if (!(file instanceof TFile)) {
+            logger.warning('read_attachment: file not found', { path });
+            return { content: [{ type: 'text', text: ACCESS_DENIED_MSG }], isError: true };
+        }
+        if (!plugin.security.isAllowed(file)) {
+            logger.warning('read_attachment: access denied by tag rule', { path });
+            return { content: [{ type: 'text', text: ACCESS_DENIED_MSG }], isError: true };
+        }
+        const ext = file.extension;
+        const mimeType = getMimeType(ext);
+        const arrayBuffer = await plugin.app.vault.readBinary(file);
+        const base64 = Buffer.from(arrayBuffer).toString('base64');
+
+        if (isImageMime(mimeType)) {
+            return {
+                content: [{
+                    type: 'image' as const,
+                    data: base64,
+                    mimeType,
+                }],
+            };
+        }
+        return {
+            content: [{
+                type: 'text' as const,
+                text: JSON.stringify({ path, mimeType, sizeBytes: arrayBuffer.byteLength }),
+            }],
+        };
+    }));
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,21 @@
 import { CachedMetadata } from 'obsidian';
 
+const MIME_TYPES: Record<string, string> = {
+    png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg',
+    gif: 'image/gif', svg: 'image/svg+xml', webp: 'image/webp',
+    bmp: 'image/bmp', ico: 'image/x-icon', tiff: 'image/tiff',
+    pdf: 'application/pdf', mp3: 'audio/mpeg', wav: 'audio/wav',
+    mp4: 'video/mp4', zip: 'application/zip',
+};
+
+export function getMimeType(extension: string): string {
+    return MIME_TYPES[extension.toLowerCase()] ?? 'application/octet-stream';
+}
+
+export function isImageMime(mimeType: string): boolean {
+    return mimeType.startsWith('image/');
+}
+
 export function normalizePath(p: string): string {
     const segments = p.split('/').filter(s => s !== '.' && s !== '');
     const resolved: string[] = [];

--- a/tests/tools/add-attachment.test.ts
+++ b/tests/tools/add-attachment.test.ts
@@ -1,0 +1,107 @@
+import { TFolder } from 'obsidian';
+import { registerAddAttachment } from '../../src/tools/add-attachment';
+
+describe('add_attachment tool', () => {
+    let handler: (args: any, extra: any) => Promise<any>;
+    const mockMcp = {
+        registerTool: jest.fn((_name, _opts, fn) => { handler = fn; }),
+    };
+    const mockPlugin = {
+        app: {
+            vault: {
+                getAbstractFileByPath: jest.fn(),
+                createFolder: jest.fn().mockResolvedValue(undefined),
+                createBinary: jest.fn().mockResolvedValue(undefined),
+            },
+            fileManager: {
+                getAvailablePathForAttachment: jest.fn().mockReturnValue('Attachments/diagram.png'),
+            },
+            metadataCache: {
+                getFileCache: jest.fn(() => null),
+            },
+        },
+        security: {
+            isAllowed: jest.fn().mockReturnValue(true),
+        },
+    };
+    const mockTracker = { track: (_name: string, fn: any) => fn };
+    const mockLogger = { info: jest.fn(), warning: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+    const smallBase64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64');
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockPlugin.security.isAllowed.mockReturnValue(true);
+        mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(null);
+        registerAddAttachment(mockMcp as any, mockPlugin as any, mockTracker as any, mockLogger as any);
+    });
+
+    test('creates attachment with explicit folder', async () => {
+        const result = await handler(
+            { filename: 'diagram.png', data: smallBase64, folder: 'Images' },
+            { sessionId: 's1' },
+        );
+        expect(mockPlugin.app.vault.createFolder).toHaveBeenCalledWith('Images');
+        expect(mockPlugin.app.vault.createBinary).toHaveBeenCalledWith(
+            'Images/diagram.png',
+            expect.any(ArrayBuffer),
+        );
+        expect(result.content[0].text).toContain('Images/diagram.png');
+    });
+
+    test('creates attachment using getAvailablePathForAttachment when no folder', async () => {
+        mockPlugin.app.fileManager.getAvailablePathForAttachment.mockReturnValue('Attachments/photo.jpg');
+        const result = await handler(
+            { filename: 'photo.jpg', data: smallBase64 },
+            { sessionId: 's1' },
+        );
+        expect(mockPlugin.app.fileManager.getAvailablePathForAttachment).toHaveBeenCalledWith('photo.jpg');
+        expect(mockPlugin.app.vault.createBinary).toHaveBeenCalledWith(
+            'Attachments/photo.jpg',
+            expect.any(ArrayBuffer),
+        );
+        expect(result.content[0].text).toContain('Attachments/photo.jpg');
+    });
+
+    test('returns error when data exceeds size limit', async () => {
+        const hugeData = 'A'.repeat(10 * 1024 * 1024 + 1);
+        const result = await handler(
+            { filename: 'big.bin', data: hugeData },
+            { sessionId: 's1' },
+        );
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('exceeds maximum size');
+        expect(mockPlugin.app.vault.createBinary).not.toHaveBeenCalled();
+    });
+
+    test('returns error when folder is access-denied', async () => {
+        mockPlugin.security.isAllowed.mockReturnValueOnce(false);
+        const result = await handler(
+            { filename: 'img.png', data: smallBase64, folder: 'Secret' },
+            { sessionId: 's1' },
+        );
+        expect(result.isError).toBe(true);
+        expect(mockPlugin.app.vault.createBinary).not.toHaveBeenCalled();
+    });
+
+    test('handles existing folder gracefully', async () => {
+        const folder = new TFolder();
+        folder.path = 'Images';
+        mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(folder);
+        const result = await handler(
+            { filename: 'img.png', data: smallBase64, folder: 'Images' },
+            { sessionId: 's1' },
+        );
+        expect(mockPlugin.app.vault.createFolder).not.toHaveBeenCalled();
+        expect(mockPlugin.app.vault.createBinary).toHaveBeenCalled();
+        expect(result.content[0].text).toContain('Images/img.png');
+    });
+
+    test('returns the vault-relative path for embedding', async () => {
+        const result = await handler(
+            { filename: 'chart.svg', data: smallBase64, folder: 'Assets' },
+            { sessionId: 's1' },
+        );
+        expect(result.content[0].text).toBe('Created attachment at Assets/chart.svg');
+    });
+});

--- a/tests/tools/read-attachment.test.ts
+++ b/tests/tools/read-attachment.test.ts
@@ -1,0 +1,101 @@
+import { TFile } from 'obsidian';
+import { registerReadAttachment } from '../../src/tools/read-attachment';
+
+describe('read_attachment tool', () => {
+    let handler: (args: any, extra: any) => Promise<any>;
+    const mockMcp = {
+        registerTool: jest.fn((_name, _opts, fn) => { handler = fn; }),
+    };
+    const mockPlugin = {
+        app: {
+            vault: {
+                getAbstractFileByPath: jest.fn(),
+                readBinary: jest.fn(),
+            },
+            metadataCache: {
+                getFileCache: jest.fn(() => null),
+            },
+        },
+        security: {
+            isAllowed: jest.fn().mockReturnValue(true),
+        },
+    };
+    const mockTracker = { track: (_name: string, fn: any) => fn };
+    const mockLogger = { info: jest.fn(), warning: jest.fn(), error: jest.fn(), debug: jest.fn() };
+
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer;
+    const mockImageFile = Object.assign(new TFile(), {
+        path: 'Attachments/diagram.png',
+        name: 'diagram.png',
+        extension: 'png',
+        stat: { mtime: 1000, ctime: 900, size: 4 },
+    });
+    const mockPdfFile = Object.assign(new TFile(), {
+        path: 'Docs/report.pdf',
+        name: 'report.pdf',
+        extension: 'pdf',
+        stat: { mtime: 1000, ctime: 900, size: 100 },
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockPlugin.security.isAllowed.mockReturnValue(true);
+        mockPlugin.app.vault.readBinary.mockResolvedValue(pngBytes);
+        registerReadAttachment(mockMcp as any, mockPlugin as any, mockTracker as any, mockLogger as any);
+    });
+
+    test('reads image file and returns ImageContent with correct base64/mimeType', async () => {
+        mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(mockImageFile);
+        const result = await handler({ path: 'Attachments/diagram.png' }, { sessionId: 's1' });
+        expect(result.content).toHaveLength(1);
+        expect(result.content[0].type).toBe('image');
+        expect(result.content[0].mimeType).toBe('image/png');
+        expect(result.content[0].data).toBe(Buffer.from(pngBytes).toString('base64'));
+    });
+
+    test('reads non-image file and returns text content with metadata', async () => {
+        const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]).buffer;
+        mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(mockPdfFile);
+        mockPlugin.app.vault.readBinary.mockResolvedValue(pdfBytes);
+        const result = await handler({ path: 'Docs/report.pdf' }, { sessionId: 's1' });
+        expect(result.content[0].type).toBe('text');
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.path).toBe('Docs/report.pdf');
+        expect(parsed.mimeType).toBe('application/pdf');
+        expect(parsed.sizeBytes).toBe(4);
+    });
+
+    test('returns error for non-existent path', async () => {
+        mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(null);
+        const result = await handler({ path: 'missing.png' }, { sessionId: 's1' });
+        expect(result.isError).toBe(true);
+    });
+
+    test('returns error for access-denied path', async () => {
+        mockPlugin.security.isAllowed.mockReturnValue(false);
+        const result = await handler({ path: 'Secret/img.png' }, { sessionId: 's1' });
+        expect(result.isError).toBe(true);
+        expect(mockPlugin.app.vault.readBinary).not.toHaveBeenCalled();
+    });
+
+    test('returns error when tag rule blocks access', async () => {
+        mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(mockImageFile);
+        mockPlugin.security.isAllowed
+            .mockReturnValueOnce(true)   // path check passes
+            .mockReturnValueOnce(false); // file (tag) check fails
+        const result = await handler({ path: 'Attachments/diagram.png' }, { sessionId: 's1' });
+        expect(result.isError).toBe(true);
+        expect(mockPlugin.app.vault.readBinary).not.toHaveBeenCalled();
+    });
+
+    test('detects MIME type from extension correctly', async () => {
+        const jpgFile = Object.assign(new TFile(), {
+            path: 'photo.jpg', name: 'photo.jpg', extension: 'jpg',
+            stat: { mtime: 1000, ctime: 900, size: 4 },
+        });
+        mockPlugin.app.vault.getAbstractFileByPath.mockReturnValue(jpgFile);
+        const result = await handler({ path: 'photo.jpg' }, { sessionId: 's1' });
+        expect(result.content[0].type).toBe('image');
+        expect(result.content[0].mimeType).toBe('image/jpeg');
+    });
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import { normalizePath, getTagsFromCache } from '../src/utils';
+import { normalizePath, getTagsFromCache, getMimeType, isImageMime } from '../src/utils';
 
 describe('normalizePath', () => {
     test('removes .. segments', () => {
@@ -18,6 +18,44 @@ describe('normalizePath', () => {
     });
     test('handles empty string', () => {
         expect(normalizePath('')).toBe('');
+    });
+});
+
+describe('getMimeType', () => {
+    test('returns correct MIME for known image extensions', () => {
+        expect(getMimeType('png')).toBe('image/png');
+        expect(getMimeType('jpg')).toBe('image/jpeg');
+        expect(getMimeType('jpeg')).toBe('image/jpeg');
+        expect(getMimeType('gif')).toBe('image/gif');
+        expect(getMimeType('webp')).toBe('image/webp');
+        expect(getMimeType('svg')).toBe('image/svg+xml');
+    });
+    test('returns correct MIME for non-image extensions', () => {
+        expect(getMimeType('pdf')).toBe('application/pdf');
+        expect(getMimeType('mp3')).toBe('audio/mpeg');
+        expect(getMimeType('mp4')).toBe('video/mp4');
+        expect(getMimeType('zip')).toBe('application/zip');
+    });
+    test('returns application/octet-stream for unknown extensions', () => {
+        expect(getMimeType('xyz')).toBe('application/octet-stream');
+        expect(getMimeType('bin')).toBe('application/octet-stream');
+    });
+    test('is case-insensitive', () => {
+        expect(getMimeType('PNG')).toBe('image/png');
+        expect(getMimeType('Jpg')).toBe('image/jpeg');
+    });
+});
+
+describe('isImageMime', () => {
+    test('returns true for image MIME types', () => {
+        expect(isImageMime('image/png')).toBe(true);
+        expect(isImageMime('image/jpeg')).toBe(true);
+        expect(isImageMime('image/svg+xml')).toBe(true);
+    });
+    test('returns false for non-image MIME types', () => {
+        expect(isImageMime('application/pdf')).toBe(false);
+        expect(isImageMime('audio/mpeg')).toBe(false);
+        expect(isImageMime('application/octet-stream')).toBe(false);
     });
 });
 


### PR DESCRIPTION
## Summary

- Adds `read_attachment` tool that reads binary files from the vault — images are returned as MCP `ImageContent` (`{ type: "image", data, mimeType }`) so AI models can actually see them; non-image files return metadata (path, mimeType, sizeBytes)
- Adds `add_attachment` tool that saves base64-encoded binary data to the vault, with optional explicit folder or Obsidian's configured attachment folder via `fileManager.getAvailablePathForAttachment()`
- Adds MIME type utilities (`getMimeType`, `isImageMime`) in `src/utils.ts` and a `MAX_ATTACHMENT_SIZE` (10MB) constant

Closes #40

## Test plan

- [x] `npm test` — 131 tests pass (12 new tests for read-attachment, add-attachment, and MIME utilities)
- [x] `npm run build` — builds without errors
- [ ] Dogfood: initialize MCP session, call `read_attachment` on an existing image in the vault
- [ ] Dogfood: call `add_attachment` with a small base64-encoded PNG, verify file appears in vault
- [ ] Verify security rules block access to blacklisted paths/tags for both tools