### PR TITLE
feat: configurable listen address (0.0.0.0 support)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,87 +1,93 @@
-import * as crypto from 'crypto';
-import { Plugin } from 'obsidian';
-import { McpPluginSettings, DEFAULT_SETTINGS, ToolUsageStats } from './types';
-import { SecurityManager } from './security';
-import { McpHttpServer } from './server';
-import { McpSettingTab } from './settings';
-import { StatsTracker } from './stats';
-import { ResourceSubscriptionManager } from './resources/subscriptions';
+import * as crypto from "crypto";
+import { Plugin } from "obsidian";
+import { McpPluginSettings, DEFAULT_SETTINGS, ToolUsageStats } from "./types";
+import { SecurityManager } from "./security";
+import { McpHttpServer } from "./server";
+import { McpSettingTab } from "./settings";
+import { StatsTracker } from "./stats";
+import { ResourceSubscriptionManager } from "./resources/subscriptions";
 
 export default class McpPlugin extends Plugin {
-    settings: McpPluginSettings = { ...DEFAULT_SETTINGS };
-    toolStats: ToolUsageStats = {};
-    statsTracker!: StatsTracker;
-    security!: SecurityManager;
-    mcpServer!: McpHttpServer;
-    private subscriptionManager!: ResourceSubscriptionManager;
+  settings: McpPluginSettings = { ...DEFAULT_SETTINGS };
+  toolStats: ToolUsageStats = {};
+  statsTracker!: StatsTracker;
+  security!: SecurityManager;
+  mcpServer!: McpHttpServer;
+  private subscriptionManager!: ResourceSubscriptionManager;
 
-    async onload(): Promise<void> {
-        await this.loadSettings();
+  async onload(): Promise<void> {
+    await this.loadSettings();
 
-        if (!this.settings.authToken) {
-            this.settings.authToken = crypto.randomBytes(16).toString('hex');
-            await this.saveSettings();
-        }
-
-        this.statsTracker = new StatsTracker(
-            () => this.toolStats,
-            (stats) => { this.toolStats = stats; },
-            () => this.saveStats(),
-        );
-
-        this.security = new SecurityManager(this);
-        this.mcpServer = new McpHttpServer(this);
-        this.statsTracker.setOnToolResult((sessionId, toolName, success) => {
-            this.mcpServer.recordSessionToolCall(sessionId, toolName, success);
-        });
-        this.subscriptionManager = new ResourceSubscriptionManager(this);
-        this.mcpServer.setSubscriptionManager(this.subscriptionManager);
-        this.addSettingTab(new McpSettingTab(this.app, this));
-        this.mcpServer.start();
-        this.subscriptionManager.start();
+    if (!this.settings.authToken) {
+      this.settings.authToken = crypto.randomBytes(16).toString("hex");
+      await this.saveSettings();
     }
 
-    async onunload(): Promise<void> {
-        await this.statsTracker.flush();
-        this.subscriptionManager.stop();
-        this.mcpServer.stop();
+    this.statsTracker = new StatsTracker(
+      () => this.toolStats,
+      (stats) => {
+        this.toolStats = stats;
+      },
+      () => this.saveStats(),
+    );
+
+    this.security = new SecurityManager(this);
+    this.mcpServer = new McpHttpServer(this);
+    this.statsTracker.setOnToolResult((sessionId, toolName, success) => {
+      this.mcpServer.recordSessionToolCall(sessionId, toolName, success);
+    });
+    this.subscriptionManager = new ResourceSubscriptionManager(this);
+    this.mcpServer.setSubscriptionManager(this.subscriptionManager);
+    this.addSettingTab(new McpSettingTab(this.app, this));
+    this.mcpServer.start();
+    this.subscriptionManager.start();
+  }
+
+  async onunload(): Promise<void> {
+    await this.statsTracker.flush();
+    this.subscriptionManager.stop();
+    this.mcpServer.stop();
+  }
+
+  async loadSettings(): Promise<void> {
+    const raw = (await this.loadData()) ?? {};
+
+    // Backward-compatible: detect old format (flat settings) vs new { settings, toolStats }
+    if ("settings" in raw && typeof raw.settings === "object") {
+      this.settings = { ...DEFAULT_SETTINGS, ...raw.settings };
+      this.toolStats = raw.toolStats ?? {};
+    } else {
+      this.settings = { ...DEFAULT_SETTINGS, ...raw };
+      this.toolStats = {};
     }
 
-    async loadSettings(): Promise<void> {
-        const raw = (await this.loadData()) ?? {};
-
-        // Backward-compatible: detect old format (flat settings) vs new { settings, toolStats }
-        if ('settings' in raw && typeof raw.settings === 'object') {
-            this.settings = { ...DEFAULT_SETTINGS, ...raw.settings };
-            this.toolStats = raw.toolStats ?? {};
-        } else {
-            this.settings = { ...DEFAULT_SETTINGS, ...raw };
-            this.toolStats = {};
-        }
-
-        if (this.settings.port < 1024 || this.settings.port > 65535) {
-            this.settings.port = DEFAULT_SETTINGS.port;
-        }
-        if (this.security) this.security.reloadRules();
+    if (this.settings.port < 1024 || this.settings.port > 65535) {
+      this.settings.port = DEFAULT_SETTINGS.port;
     }
-
-    async saveSettings(): Promise<void> {
-        await this.saveData({ settings: this.settings, toolStats: this.toolStats });
-        if (this.security) this.security.reloadRules();
+    const validAddresses = ["127.0.0.1", "0.0.0.0"];
+    if (!validAddresses.includes(this.settings.listenAddress)) {
+      this.settings.listenAddress = DEFAULT_SETTINGS.listenAddress;
     }
+    if (this.security) this.security.reloadRules();
+  }
 
-    async saveStats(): Promise<void> {
-        await this.saveData({ settings: this.settings, toolStats: this.toolStats });
-    }
+  async saveSettings(): Promise<void> {
+    await this.saveData({ settings: this.settings, toolStats: this.toolStats });
+    if (this.security) this.security.reloadRules();
+  }
 
-    async resetStats(): Promise<void> {
-        this.toolStats = {};
-        await this.saveStats();
-    }
+  async saveStats(): Promise<void> {
+    await this.saveData({ settings: this.settings, toolStats: this.toolStats });
+  }
 
-    restartServer(): void {
-        if (!this.mcpServer) return;
-        this.mcpServer.stop();
-        this.mcpServer.start();
-    }
+  async resetStats(): Promise<void> {
+    this.toolStats = {};
+    await this.saveStats();
+  }
+
+  restartServer(): void {
+    if (!this.mcpServer) return;
+    this.mcpServer.stop();
+    this.mcpServer.start();
+  }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,22 +1,22 @@
-import * as crypto from 'crypto';
-import * as http from 'http';
-import express, { Request, Response, NextFunction } from 'express';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { Notice } from 'obsidian';
-import type McpPlugin from './main';
-import { registerTools } from './tools';
-import { buildInstructions } from './instructions';
-import { McpLogger } from './logging';
-import { registerPrompts } from './prompts';
-import { registerResources } from './resources';
-import type { ResourceSubscriptionManager } from './resources/subscriptions';
-import type { ToolUsageStats, SessionSummary } from './types';
-import { recordToolCall, recordToolSuccess, recordToolFailure } from './stats';
+import * as crypto from "crypto";
+import * as http from "http";
+import express, { Request, Response, NextFunction } from "express";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { Notice } from "obsidian";
+import type McpPlugin from "./main";
+import { registerTools } from "./tools";
+import { buildInstructions } from "./instructions";
+import { McpLogger } from "./logging";
+import { registerPrompts } from "./prompts";
+import { registerResources } from "./resources";
+import type { ResourceSubscriptionManager } from "./resources/subscriptions";
+import type { ToolUsageStats, SessionSummary } from "./types";
+import { recordToolCall, recordToolSuccess, recordToolFailure } from "./stats";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const PKG_VERSION: string = require('../package.json').version;
+const PKG_VERSION: string = require("../package.json").version;
 
 const MAX_CLIENT_STRING_LENGTH = 128;
 const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
@@ -24,311 +24,345 @@ const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_SESSIONS = 10;
 
 interface ActiveSession {
-    transport: StreamableHTTPServerTransport;
-    mcp: McpServer;
-    lastAccess: number;
-    connectedAt: number;
-    clientName: string;
-    clientVersion: string;
-    toolStats: ToolUsageStats;
+  transport: StreamableHTTPServerTransport;
+  mcp: McpServer;
+  lastAccess: number;
+  connectedAt: number;
+  clientName: string;
+  clientVersion: string;
+  toolStats: ToolUsageStats;
 }
 
 export class McpHttpServer {
-    private httpServer: http.Server | null = null;
-    private sessions = new Map<string, ActiveSession>();
-    private cleanupInterval: ReturnType<typeof setInterval> | null = null;
-    private subscriptionManager: ResourceSubscriptionManager | null = null;
+  private httpServer: http.Server | null = null;
+  private sessions = new Map<string, ActiveSession>();
+  private cleanupInterval: ReturnType<typeof setInterval> | null = null;
+  private subscriptionManager: ResourceSubscriptionManager | null = null;
 
-    constructor(private plugin: McpPlugin) {}
+  constructor(private plugin: McpPlugin) {}
 
-    setSubscriptionManager(manager: ResourceSubscriptionManager): void {
-        this.subscriptionManager = manager;
+  setSubscriptionManager(manager: ResourceSubscriptionManager): void {
+    this.subscriptionManager = manager;
+  }
+
+  getSessionSummaries(): SessionSummary[] {
+    const now = Date.now();
+    const summaries: SessionSummary[] = [];
+    for (const [id, session] of this.sessions) {
+      const totals = Object.values(session.toolStats).reduce(
+        (acc, s) => ({
+          total: acc.total + s.total,
+          successful: acc.successful + s.successful,
+          failed: acc.failed + s.failed,
+        }),
+        { total: 0, successful: 0, failed: 0 },
+      );
+      summaries.push({
+        sessionId: id.slice(-8),
+        clientName: session.clientName,
+        clientVersion: session.clientVersion,
+        connectedAt: new Date(session.connectedAt).toISOString(),
+        lastActiveAt: new Date(session.lastAccess).toISOString(),
+        durationSeconds: Math.round((now - session.connectedAt) / 1000),
+        toolCalls: {
+          ...totals,
+          byTool: { ...session.toolStats },
+        },
+      });
+    }
+    return summaries;
+  }
+
+  recordSessionToolCall(
+    sessionId: string,
+    toolName: string,
+    success: boolean,
+  ): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) return;
+    session.toolStats = recordToolCall(session.toolStats, toolName);
+    if (success) {
+      session.toolStats = recordToolSuccess(session.toolStats, toolName);
+    } else {
+      session.toolStats = recordToolFailure(session.toolStats, toolName);
+    }
+  }
+
+  stop(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = null;
     }
 
-    getSessionSummaries(): SessionSummary[] {
-        const now = Date.now();
-        const summaries: SessionSummary[] = [];
-        for (const [id, session] of this.sessions) {
-            const totals = Object.values(session.toolStats).reduce(
-                (acc, s) => ({
-                    total: acc.total + s.total,
-                    successful: acc.successful + s.successful,
-                    failed: acc.failed + s.failed,
-                }),
-                { total: 0, successful: 0, failed: 0 },
-            );
-            summaries.push({
-                sessionId: id.slice(-8),
-                clientName: session.clientName,
-                clientVersion: session.clientVersion,
-                connectedAt: new Date(session.connectedAt).toISOString(),
-                lastActiveAt: new Date(session.lastAccess).toISOString(),
-                durationSeconds: Math.round((now - session.connectedAt) / 1000),
-                toolCalls: {
-                    ...totals,
-                    byTool: { ...session.toolStats },
-                },
-            });
-        }
-        return summaries;
+    for (const [, session] of this.sessions) {
+      session.transport.close().catch(() => {
+        /* intentionally ignored */
+      });
     }
+    this.sessions.clear();
 
-    recordSessionToolCall(sessionId: string, toolName: string, success: boolean): void {
-        const session = this.sessions.get(sessionId);
-        if (!session) return;
-        session.toolStats = recordToolCall(session.toolStats, toolName);
-        if (success) {
-            session.toolStats = recordToolSuccess(session.toolStats, toolName);
-        } else {
-            session.toolStats = recordToolFailure(session.toolStats, toolName);
-        }
+    if (this.httpServer) {
+      this.httpServer.close();
+      this.httpServer = null;
     }
+  }
 
-    stop(): void {
-        if (this.cleanupInterval) {
-            clearInterval(this.cleanupInterval);
-            this.cleanupInterval = null;
-        }
+  start(): void {
+    this.stop();
 
-        for (const [, session] of this.sessions) {
-            session.transport.close().catch(() => { /* intentionally ignored */ });
-        }
-        this.sessions.clear();
+    try {
+      const app = express();
+      app.use(express.json());
+      app.use(this.createAuthMiddleware());
 
-        if (this.httpServer) {
-            this.httpServer.close();
-            this.httpServer = null;
-        }
-    }
-
-    start(): void {
-        this.stop();
-
-        try {
-            const app = express();
-            app.use(express.json());
-            app.use(this.createAuthMiddleware());
-
-            app.all('/mcp', (req: Request, res: Response) => {
-                this.handleMcpRequest(req, res).catch(() => {
-                    if (!res.headersSent) {
-                        res.status(500).json({ error: 'Internal server error.' });
-                    }
-                });
-            });
-
-            app.get('/sse', (_req: Request, res: Response) => {
-                res.status(410).json({
-                    error: 'The /sse endpoint is deprecated. Use /mcp with Streamable HTTP transport.',
-                });
-            });
-
-            this.startSessionCleanup();
-
-            const port = this.plugin.settings.port;
-            this.httpServer = app.listen(port, '127.0.0.1', () => {
-                new Notice(`MCP Server Online (Port ${port})`);
-            });
-
-            this.httpServer.on('error', (err: NodeJS.ErrnoException) => {
-                if (err.code === 'EADDRINUSE') {
-                    new Notice(`MCP Error: Port ${port} busy`);
-                } else {
-                    new Notice(`MCP Server Error: ${err.message}`);
-                }
-            });
-        } catch {
-            new Notice('MCP Server Failed to Start');
-        }
-    }
-
-    private startSessionCleanup(): void {
-        this.cleanupInterval = setInterval(() => {
-            const now = Date.now();
-            for (const [id, session] of this.sessions) {
-                if (now - session.lastAccess > SESSION_TTL_MS) {
-                    session.transport.close().catch(() => { /* intentionally ignored */ });
-                    this.sessions.delete(id);
-                }
-            }
-        }, CLEANUP_INTERVAL_MS);
-    }
-
-    private evictOldestSession(): void {
-        let oldestId: string | null = null;
-        let oldestTime = Infinity;
-        for (const [id, session] of this.sessions) {
-            if (session.lastAccess < oldestTime) {
-                oldestTime = session.lastAccess;
-                oldestId = id;
-            }
-        }
-        if (oldestId) {
-            const session = this.sessions.get(oldestId)!;
-            session.transport.close().catch(() => { /* intentionally ignored */ });
-            this.sessions.delete(oldestId);
-        }
-    }
-
-    private createAuthMiddleware(): (req: Request, res: Response, next: NextFunction) => void {
-        return (req: Request, res: Response, next: NextFunction) => {
-            if (!this.plugin.settings.requireAuth) {
-                next();
-                return;
-            }
-
-            const serverToken = this.plugin.settings.authToken;
-            if (!serverToken) {
-                res.status(500).json({ error: 'Server misconfigured: no auth token.' });
-                return;
-            }
-
-            let clientToken: string | undefined;
-            const authHeader = req.headers.authorization;
-            if (authHeader?.startsWith('Bearer ')) {
-                clientToken = authHeader.slice(7);
-            } else if (typeof req.query.token === 'string') {
-                clientToken = req.query.token;
-            }
-
-            if (!clientToken || clientToken.length === 0) {
-                res.status(403).json({ error: 'Unauthorized.' });
-                return;
-            }
-
-            const serverBuf = Buffer.from(serverToken);
-            const clientBuf = Buffer.from(clientToken);
-            if (serverBuf.length !== clientBuf.length || !crypto.timingSafeEqual(serverBuf, clientBuf)) {
-                res.status(403).json({ error: 'Unauthorized.' });
-                return;
-            }
-
-            next();
-        };
-    }
-
-    private hasInitializeRequest(body: unknown): boolean {
-        if (Array.isArray(body)) {
-            return body.some(msg => isInitializeRequest(msg));
-        }
-        return isInitializeRequest(body);
-    }
-
-    private async handleMcpRequest(req: Request, res: Response): Promise<void> {
-        const sessionId = req.headers['mcp-session-id'] as string | undefined;
-
-        // Route GET/DELETE to existing sessions
-        if (req.method === 'GET' || req.method === 'DELETE') {
-            if (sessionId && this.sessions.has(sessionId)) {
-                const session = this.sessions.get(sessionId)!;
-                session.lastAccess = Date.now();
-                await session.transport.handleRequest(req, res, req.body);
-                return;
-            }
-            const status = req.method === 'GET' ? 400 : 404;
-            const error = req.method === 'GET'
-                ? 'Invalid or missing session.'
-                : 'Session not found.';
-            res.status(status).json({ error });
-            return;
-        }
-
-        if (req.method !== 'POST') {
-            res.status(405).json({ error: 'Method not allowed.' });
-            return;
-        }
-
-        // Route POST to existing session
-        if (sessionId && this.sessions.has(sessionId)) {
-            const session = this.sessions.get(sessionId)!;
-            session.lastAccess = Date.now();
-            await session.transport.handleRequest(req, res, req.body);
-            return;
-        }
-
-        const isInitRequest = this.hasInitializeRequest(req.body);
-
-        // Stale session ID: provided but no longer exists (expired/evicted/server restarted)
-        if (sessionId && !isInitRequest) {
-            res.status(404).json({
-                error: 'Session not found — it may have expired or the server may have restarted. '
-                    + 'To recover, send a new "initialize" request (method: "initialize") without '
-                    + 'the mcp-session-id header to create a fresh session, then use the returned '
-                    + 'mcp-session-id for subsequent requests.',
-                code: 'SESSION_EXPIRED',
-            });
-            return;
-        }
-
-        // No session and not an initialize request
-        if (!isInitRequest) {
-            res.status(400).json({
-                error: 'Missing session. The MCP protocol requires a session before calling tools. '
-                    + 'Send a POST to /mcp with method "initialize" (no mcp-session-id header) first, '
-                    + 'then include the mcp-session-id from the response header in all subsequent requests.',
-                code: 'INITIALIZATION_REQUIRED',
-            });
-            return;
-        }
-
-        // Evict oldest session if at capacity
-        if (this.sessions.size >= MAX_SESSIONS) {
-            this.evictOldestSession();
-        }
-
-        // Extract client info from initialize request
-        const clientNameHeader = req.headers['x-client-name'] as string | undefined;
-        const initBody = Array.isArray(req.body)
-            ? req.body.find((msg: Record<string, unknown>) => isInitializeRequest(msg))
-            : req.body;
-        const clientInfo = (initBody?.params as Record<string, unknown>)?.clientInfo as
-            { name?: string; version?: string } | undefined;
-        const rawName = clientNameHeader || clientInfo?.name || 'Unknown';
-        const rawVersion = clientInfo?.version || '';
-        const clientName = typeof rawName === 'string' ? rawName.slice(0, MAX_CLIENT_STRING_LENGTH) : 'Unknown';
-        const clientVersion = typeof rawVersion === 'string' ? rawVersion.slice(0, MAX_CLIENT_STRING_LENGTH) : '';
-
-        const transport = new StreamableHTTPServerTransport({
-            sessionIdGenerator: () => crypto.randomUUID(),
-            onsessioninitialized: (id: string) => {
-                const now = Date.now();
-                this.sessions.set(id, {
-                    transport,
-                    mcp,
-                    lastAccess: now,
-                    connectedAt: now,
-                    clientName,
-                    clientVersion,
-                    toolStats: {},
-                });
-            },
+      app.all("/mcp", (req: Request, res: Response) => {
+        this.handleMcpRequest(req, res).catch(() => {
+          if (!res.headersSent) {
+            res.status(500).json({ error: "Internal server error." });
+          }
         });
+      });
 
-        const instructions = buildInstructions(this.plugin);
-        const mcp = new McpServer({
-            name: 'Obsidian MCP',
-            version: PKG_VERSION,
-        }, instructions ? { instructions } : undefined);
+      app.get("/sse", (_req: Request, res: Response) => {
+        res.status(410).json({
+          error:
+            "The /sse endpoint is deprecated. Use /mcp with Streamable HTTP transport.",
+        });
+      });
 
-        const logger = new McpLogger(mcp, 'obsidian-mcp');
-        registerTools(mcp, this.plugin, logger);
-        registerPrompts(mcp, this.plugin);
-        registerResources(mcp, this.plugin);
+      this.startSessionCleanup();
 
-        if (this.subscriptionManager) {
-            this.subscriptionManager.registerSession(mcp);
+      const port = this.plugin.settings.port;
+      const host = this.plugin.settings.listenAddress;
+      this.httpServer = app.listen(port, host, () => {
+        const label = host === "0.0.0.0" ? `0.0.0.0:${port}` : `Port ${port}`;
+        new Notice(`MCP Server Online (${label})`);
+      });
+
+      this.httpServer.on("error", (err: NodeJS.ErrnoException) => {
+        if (err.code === "EADDRINUSE") {
+          new Notice(`MCP Error: Port ${port} busy`);
+        } else {
+          new Notice(`MCP Server Error: ${err.message}`);
         }
-
-        transport.onclose = () => {
-            if (transport.sessionId) {
-                this.sessions.delete(transport.sessionId);
-            }
-            if (this.subscriptionManager) {
-                this.subscriptionManager.unregisterSession(mcp);
-            }
-        };
-
-        await mcp.connect(transport);
-        await transport.handleRequest(req, res, req.body);
+      });
+    } catch {
+      new Notice("MCP Server Failed to Start");
     }
+  }
+
+  private startSessionCleanup(): void {
+    this.cleanupInterval = setInterval(() => {
+      const now = Date.now();
+      for (const [id, session] of this.sessions) {
+        if (now - session.lastAccess > SESSION_TTL_MS) {
+          session.transport.close().catch(() => {
+            /* intentionally ignored */
+          });
+          this.sessions.delete(id);
+        }
+      }
+    }, CLEANUP_INTERVAL_MS);
+  }
+
+  private evictOldestSession(): void {
+    let oldestId: string | null = null;
+    let oldestTime = Infinity;
+    for (const [id, session] of this.sessions) {
+      if (session.lastAccess < oldestTime) {
+        oldestTime = session.lastAccess;
+        oldestId = id;
+      }
+    }
+    if (oldestId) {
+      const session = this.sessions.get(oldestId)!;
+      session.transport.close().catch(() => {
+        /* intentionally ignored */
+      });
+      this.sessions.delete(oldestId);
+    }
+  }
+
+  private createAuthMiddleware(): (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => void {
+    return (req: Request, res: Response, next: NextFunction) => {
+      if (!this.plugin.settings.requireAuth) {
+        next();
+        return;
+      }
+
+      const serverToken = this.plugin.settings.authToken;
+      if (!serverToken) {
+        res.status(500).json({ error: "Server misconfigured: no auth token." });
+        return;
+      }
+
+      let clientToken: string | undefined;
+      const authHeader = req.headers.authorization;
+      if (authHeader?.startsWith("Bearer ")) {
+        clientToken = authHeader.slice(7);
+      } else if (typeof req.query.token === "string") {
+        clientToken = req.query.token;
+      }
+
+      if (!clientToken || clientToken.length === 0) {
+        res.status(403).json({ error: "Unauthorized." });
+        return;
+      }
+
+      const serverBuf = Buffer.from(serverToken);
+      const clientBuf = Buffer.from(clientToken);
+      if (
+        serverBuf.length !== clientBuf.length ||
+        !crypto.timingSafeEqual(serverBuf, clientBuf)
+      ) {
+        res.status(403).json({ error: "Unauthorized." });
+        return;
+      }
+
+      next();
+    };
+  }
+
+  private hasInitializeRequest(body: unknown): boolean {
+    if (Array.isArray(body)) {
+      return body.some((msg) => isInitializeRequest(msg));
+    }
+    return isInitializeRequest(body);
+  }
+
+  private async handleMcpRequest(req: Request, res: Response): Promise<void> {
+    const sessionId = req.headers["mcp-session-id"] as string | undefined;
+
+    // Route GET/DELETE to existing sessions
+    if (req.method === "GET" || req.method === "DELETE") {
+      if (sessionId && this.sessions.has(sessionId)) {
+        const session = this.sessions.get(sessionId)!;
+        session.lastAccess = Date.now();
+        await session.transport.handleRequest(req, res, req.body);
+        return;
+      }
+      const status = req.method === "GET" ? 400 : 404;
+      const error =
+        req.method === "GET"
+          ? "Invalid or missing session."
+          : "Session not found.";
+      res.status(status).json({ error });
+      return;
+    }
+
+    if (req.method !== "POST") {
+      res.status(405).json({ error: "Method not allowed." });
+      return;
+    }
+
+    // Route POST to existing session
+    if (sessionId && this.sessions.has(sessionId)) {
+      const session = this.sessions.get(sessionId)!;
+      session.lastAccess = Date.now();
+      await session.transport.handleRequest(req, res, req.body);
+      return;
+    }
+
+    const isInitRequest = this.hasInitializeRequest(req.body);
+
+    // Stale session ID: provided but no longer exists (expired/evicted/server restarted)
+    if (sessionId && !isInitRequest) {
+      res.status(404).json({
+        error:
+          "Session not found — it may have expired or the server may have restarted. " +
+          'To recover, send a new "initialize" request (method: "initialize") without ' +
+          "the mcp-session-id header to create a fresh session, then use the returned " +
+          "mcp-session-id for subsequent requests.",
+        code: "SESSION_EXPIRED",
+      });
+      return;
+    }
+
+    // No session and not an initialize request
+    if (!isInitRequest) {
+      res.status(400).json({
+        error:
+          "Missing session. The MCP protocol requires a session before calling tools. " +
+          'Send a POST to /mcp with method "initialize" (no mcp-session-id header) first, ' +
+          "then include the mcp-session-id from the response header in all subsequent requests.",
+        code: "INITIALIZATION_REQUIRED",
+      });
+      return;
+    }
+
+    // Evict oldest session if at capacity
+    if (this.sessions.size >= MAX_SESSIONS) {
+      this.evictOldestSession();
+    }
+
+    // Extract client info from initialize request
+    const clientNameHeader = req.headers["x-client-name"] as string | undefined;
+    const initBody = Array.isArray(req.body)
+      ? req.body.find((msg: Record<string, unknown>) =>
+          isInitializeRequest(msg),
+        )
+      : req.body;
+    const clientInfo = (initBody?.params as Record<string, unknown>)
+      ?.clientInfo as { name?: string; version?: string } | undefined;
+    const rawName = clientNameHeader || clientInfo?.name || "Unknown";
+    const rawVersion = clientInfo?.version || "";
+    const clientName =
+      typeof rawName === "string"
+        ? rawName.slice(0, MAX_CLIENT_STRING_LENGTH)
+        : "Unknown";
+    const clientVersion =
+      typeof rawVersion === "string"
+        ? rawVersion.slice(0, MAX_CLIENT_STRING_LENGTH)
+        : "";
+
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => crypto.randomUUID(),
+      onsessioninitialized: (id: string) => {
+        const now = Date.now();
+        this.sessions.set(id, {
+          transport,
+          mcp,
+          lastAccess: now,
+          connectedAt: now,
+          clientName,
+          clientVersion,
+          toolStats: {},
+        });
+      },
+    });
+
+    const instructions = buildInstructions(this.plugin);
+    const mcp = new McpServer(
+      {
+        name: "Obsidian MCP",
+        version: PKG_VERSION,
+      },
+      instructions ? { instructions } : undefined,
+    );
+
+    const logger = new McpLogger(mcp, "obsidian-mcp");
+    registerTools(mcp, this.plugin, logger);
+    registerPrompts(mcp, this.plugin);
+    registerResources(mcp, this.plugin);
+
+    if (this.subscriptionManager) {
+      this.subscriptionManager.registerSession(mcp);
+    }
+
+    transport.onclose = () => {
+      if (transport.sessionId) {
+        this.sessions.delete(transport.sessionId);
+      }
+      if (this.subscriptionManager) {
+        this.subscriptionManager.unregisterSession(mcp);
+      }
+    };
+
+    await mcp.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,325 +1,408 @@
-import * as crypto from 'crypto';
-import { App, Notice, PluginSettingTab, Setting } from 'obsidian';
-import type McpPlugin from './main';
+import * as crypto from "crypto";
+import { App, Notice, PluginSettingTab, Setting } from "obsidian";
+import type McpPlugin from "./main";
 
 export class McpSettingTab extends PluginSettingTab {
-    private plugin: McpPlugin;
-    private portRestartTimeout: ReturnType<typeof setTimeout> | null = null;
+  private plugin: McpPlugin;
+  private portRestartTimeout: ReturnType<typeof setTimeout> | null = null;
 
-    constructor(app: App, plugin: McpPlugin) {
-        super(app, plugin);
-        this.plugin = plugin;
-    }
+  constructor(app: App, plugin: McpPlugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
 
-    display(): void {
-        const { containerEl } = this;
-        containerEl.empty();
-        containerEl.createEl('h2', { text: 'Obsidian MCP Server' });
+  display(): void {
+    const { containerEl } = this;
+    containerEl.empty();
+    containerEl.createEl("h2", { text: "Obsidian MCP Server" });
 
-        // --- Server Section ---
-        new Setting(containerEl)
-            .setName('Server Port')
-            .setDesc('Port to listen on (1024-65535). Default: 27123. Server restarts on change.')
-            .addText(text => text
-                .setValue(String(this.plugin.settings.port))
-                .onChange(async (value) => {
-                    const port = parseInt(value, 10);
-                    if (isNaN(port) || port < 1024 || port > 65535) return;
-                    this.plugin.settings.port = port;
-                    await this.plugin.saveSettings();
-                    if (this.portRestartTimeout) clearTimeout(this.portRestartTimeout);
-                    this.portRestartTimeout = setTimeout(() => {
-                        this.plugin.restartServer();
-                    }, 1000);
-                }));
+    // --- Server Section ---
+    new Setting(containerEl)
+      .setName("Server Port")
+      .setDesc(
+        "Port to listen on (1024-65535). Default: 27123. Server restarts on change.",
+      )
+      .addText((text) =>
+        text
+          .setValue(String(this.plugin.settings.port))
+          .onChange(async (value) => {
+            const port = parseInt(value, 10);
+            if (isNaN(port) || port < 1024 || port > 65535) return;
+            this.plugin.settings.port = port;
+            await this.plugin.saveSettings();
+            if (this.portRestartTimeout) clearTimeout(this.portRestartTimeout);
+            this.portRestartTimeout = setTimeout(() => {
+              this.plugin.restartServer();
+            }, 1000);
+          }),
+      );
 
-        new Setting(containerEl)
-            .setName('Require Authentication')
-            .setDesc('Require Bearer token for all connections. Disable for easier local development.')
-            .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.requireAuth)
-                .onChange(async (value) => {
-                    if (!value) {
-                        const confirmed = window.confirm(
-                            'Disabling auth allows any local process to access your vault via the MCP server. Continue?'
-                        );
-                        if (!confirmed) {
-                            toggle.setValue(true);
-                            return;
-                        }
-                    }
-                    this.plugin.settings.requireAuth = value;
-                    await this.plugin.saveSettings();
-                    this.display();
-                    this.plugin.restartServer();
-                }));
-
-        if (this.plugin.settings.requireAuth) {
-            new Setting(containerEl)
-                .setName('Auth Token')
-                .setDesc('Required for connecting. Use the Authorization header: Bearer <token>')
-                .addText(text => text
-                    .setValue(this.plugin.settings.authToken)
-                    .setDisabled(true))
-                .addExtraButton(btn => btn
-                    .setIcon('copy')
-                    .onClick(() => {
-                        navigator.clipboard.writeText(this.plugin.settings.authToken);
-                        new Notice('Token copied');
-                    }));
-
-            new Setting(containerEl)
-                .setName('Regenerate Token')
-                .addButton(btn => btn
-                    .setButtonText('Regenerate')
-                    .setWarning()
-                    .onClick(async () => {
-                        this.plugin.settings.authToken = crypto.randomBytes(16).toString('hex');
-                        await this.plugin.saveSettings();
-                        this.display();
-                        this.plugin.restartServer();
-                    }));
-        }
-
-        new Setting(containerEl)
-            .setName('Access Control: Blacklist')
-            .setDesc('One rule per line. Paths: "Secret/" blocks folders/files. Tags: "#secret" blocks files with that tag.')
-            .addTextArea(text => text
-                .setPlaceholder('Secret/\n#private')
-                .setValue(this.plugin.settings.blacklist)
-                .onChange(async (value) => {
-                    this.plugin.settings.blacklist = value;
-                    await this.plugin.saveSettings();
-                }));
-
-        // --- Agent Instructions Section ---
-        containerEl.createEl('h3', { text: 'Agent Instructions' });
-
-        new Setting(containerEl)
-            .setName('Enable Instructions')
-            .setDesc('Send vault context and usage guidelines to AI agents on connect. Server restarts on change.')
-            .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.enableInstructions)
-                .onChange(async (value) => {
-                    this.plugin.settings.enableInstructions = value;
-                    await this.plugin.saveSettings();
-                    this.plugin.restartServer();
-                }));
-
-        new Setting(containerEl)
-            .setName('Include Vault Structure')
-            .setDesc('Include top-level folder names in instructions.')
-            .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.includeVaultStructure)
-                .onChange(async (value) => {
-                    this.plugin.settings.includeVaultStructure = value;
-                    await this.plugin.saveSettings();
-                    this.plugin.restartServer();
-                }));
-
-        new Setting(containerEl)
-            .setName('Custom Instructions')
-            .setDesc('Additional instructions appended to the agent context. Server restarts on change.')
-            .addTextArea(text => text
-                .setPlaceholder('e.g., Always use #project tag when creating notes...')
-                .setValue(this.plugin.settings.customInstructions)
-                .onChange(async (value) => {
-                    this.plugin.settings.customInstructions = value;
-                    await this.plugin.saveSettings();
-                    this.plugin.restartServer();
-                }));
-
-        // --- Prompts Section ---
-        containerEl.createEl('h3', { text: 'Format Guides (Prompts)' });
-
-        new Setting(containerEl)
-            .setName('Enable Prompts')
-            .setDesc('Expose Obsidian format reference guides as MCP prompts. Server restarts on change.')
-            .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.enablePrompts)
-                .onChange(async (value) => {
-                    this.plugin.settings.enablePrompts = value;
-                    await this.plugin.saveSettings();
-                    this.plugin.restartServer();
-                }));
-
-        new Setting(containerEl)
-            .setName('Obsidian Markdown Guide')
-            .setDesc('Wikilinks, embeds, callouts, frontmatter, tags.')
-            .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.enableMarkdownGuide)
-                .onChange(async (value) => {
-                    this.plugin.settings.enableMarkdownGuide = value;
-                    await this.plugin.saveSettings();
-                    this.plugin.restartServer();
-                }));
-
-        new Setting(containerEl)
-            .setName('JSON Canvas Guide')
-            .setDesc('.canvas file format reference.')
-            .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.enableCanvasGuide)
-                .onChange(async (value) => {
-                    this.plugin.settings.enableCanvasGuide = value;
-                    await this.plugin.saveSettings();
-                    this.plugin.restartServer();
-                }));
-
-        new Setting(containerEl)
-            .setName('Obsidian Bases Guide')
-            .setDesc('.base file format reference.')
-            .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.enableBasesGuide)
-                .onChange(async (value) => {
-                    this.plugin.settings.enableBasesGuide = value;
-                    await this.plugin.saveSettings();
-                    this.plugin.restartServer();
-                }));
-
-        // --- Resources Section ---
-        containerEl.createEl('h3', { text: 'Resources' });
-
-        new Setting(containerEl)
-            .setName('Enable Resources')
-            .setDesc('Expose vault content as MCP resources (notes, tags, folders, daily notes). Server restarts on change.')
-            .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.enableResources)
-                .onChange(async (value) => {
-                    this.plugin.settings.enableResources = value;
-                    await this.plugin.saveSettings();
-                    this.plugin.restartServer();
-                }));
-
-        new Setting(containerEl)
-            .setName('Enable Resource Subscriptions')
-            .setDesc('Notify connected AI agents when vault files change. Requires plugin restart.')
-            .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.enableResourceSubscriptions)
-                .onChange(async (value) => {
-                    this.plugin.settings.enableResourceSubscriptions = value;
-                    await this.plugin.saveSettings();
-                }));
-
-        new Setting(containerEl)
-            .setName('Max Resources Listed')
-            .setDesc('Maximum number of resources returned in list operations (1-5000).')
-            .addText(text => text
-                .setValue(String(this.plugin.settings.maxResourcesListed))
-                .onChange(async (value) => {
-                    const num = parseInt(value, 10);
-                    if (isNaN(num) || num < 1 || num > 5000) return;
-                    this.plugin.settings.maxResourcesListed = num;
-                    await this.plugin.saveSettings();
-                }));
-
-        // --- Smart Features Section ---
-        containerEl.createEl('h3', { text: 'Smart Features' });
-
-        new Setting(containerEl)
-            .setName('Smart Annotations')
-            .setDesc('Add contextual hints to read_note/get_active_file responses (draft status, large note warnings, broken links).')
-            .addToggle(toggle => toggle
-                .setValue(this.plugin.settings.enableSmartAnnotations)
-                .onChange(async (value) => {
-                    this.plugin.settings.enableSmartAnnotations = value;
-                    await this.plugin.saveSettings();
-                }));
-
-        // --- Sessions Section ---
-        this.renderSessionsSection(containerEl);
-
-        // --- Stats Section ---
-        this.renderStatsSection(containerEl);
-    }
-
-    private renderSessionsSection(containerEl: HTMLElement): void {
-        containerEl.createEl('h3', { text: 'Active Sessions' });
-
-        const summaries = this.plugin.mcpServer.getSessionSummaries();
-
-        if (summaries.length === 0) {
-            containerEl.createEl('p', {
-                text: 'No active sessions.',
-                cls: 'mcp-stats-empty',
-            });
-            return;
-        }
-
-        const table = containerEl.createEl('table', { cls: 'mcp-stats-table' });
-        const thead = table.createEl('thead');
-        const headerRow = thead.createEl('tr');
-        headerRow.createEl('th', { text: 'Client' });
-        headerRow.createEl('th', { text: 'Session ID' });
-        headerRow.createEl('th', { text: 'Connected' });
-        headerRow.createEl('th', { text: 'Last Active' });
-        headerRow.createEl('th', { text: 'Tool Calls' });
-
-        const tbody = table.createEl('tbody');
-        for (const s of summaries) {
-            const row = tbody.createEl('tr');
-            const clientLabel = s.clientVersion
-                ? `${s.clientName} (${s.clientVersion})`
-                : s.clientName;
-            row.createEl('td', { text: clientLabel });
-            row.createEl('td', { text: `...${s.sessionId}` });
-            row.createEl('td', { text: this.formatRelativeTime(s.connectedAt) });
-            row.createEl('td', { text: this.formatRelativeTime(s.lastActiveAt) });
-            row.createEl('td', { text: String(s.toolCalls.total) });
-        }
-    }
-
-    private formatRelativeTime(isoString: string): string {
-        const time = new Date(isoString).getTime();
-        if (isNaN(time)) return 'unknown';
-        const seconds = Math.max(0, Math.floor((Date.now() - time) / 1000));
-        if (seconds < 60) return `${seconds}s ago`;
-        const minutes = Math.floor(seconds / 60);
-        if (minutes < 60) return `${minutes}m ago`;
-        const hours = Math.floor(minutes / 60);
-        return `${hours}h ago`;
-    }
-
-    private renderStatsSection(containerEl: HTMLElement): void {
-        containerEl.createEl('h3', { text: 'Tool Usage Statistics' });
-
-        const stats = this.plugin.toolStats;
-        const toolNames = Object.keys(stats);
-
-        if (toolNames.length === 0) {
-            containerEl.createEl('p', {
-                text: 'No tool usage recorded yet.',
-                cls: 'mcp-stats-empty',
-            });
-        } else {
-            const table = containerEl.createEl('table', { cls: 'mcp-stats-table' });
-            const thead = table.createEl('thead');
-            const headerRow = thead.createEl('tr');
-            headerRow.createEl('th', { text: 'Tool' });
-            headerRow.createEl('th', { text: 'Total' });
-            headerRow.createEl('th', { text: 'Successful' });
-            headerRow.createEl('th', { text: 'Failed' });
-
-            const tbody = table.createEl('tbody');
-            for (const name of toolNames.sort()) {
-                const s = stats[name];
-                const row = tbody.createEl('tr');
-                row.createEl('td', { text: name });
-                row.createEl('td', { text: String(s.total) });
-                row.createEl('td', { text: String(s.successful) });
-                row.createEl('td', { text: String(s.failed) });
+    new Setting(containerEl)
+      .setName("Listen Address")
+      .setDesc(
+        'Network interface to bind. "127.0.0.1" = local only. "0.0.0.0" = all interfaces (LAN-accessible). Server restarts on change.',
+      )
+      .addDropdown((dropdown) =>
+        dropdown
+          .addOption("127.0.0.1", "127.0.0.1 (localhost only)")
+          .addOption("0.0.0.0", "0.0.0.0 (all interfaces)")
+          .setValue(this.plugin.settings.listenAddress)
+          .onChange(async (value) => {
+            if (value === "0.0.0.0") {
+              const confirmed = window.confirm(
+                "Binding to 0.0.0.0 exposes your vault to all devices on your local network. " +
+                  "Make sure authentication is enabled. Continue?",
+              );
+              if (!confirmed) {
+                dropdown.setValue("127.0.0.1");
+                return;
+              }
             }
-        }
+            this.plugin.settings.listenAddress = value;
+            await this.plugin.saveSettings();
+            this.plugin.restartServer();
+          }),
+      );
 
-        new Setting(containerEl)
-            .setName('Reset Statistics')
-            .setDesc('Clear all tool usage statistics.')
-            .addButton(btn => btn
-                .setButtonText('Reset')
-                .setWarning()
-                .onClick(async () => {
-                    await this.plugin.resetStats();
-                    this.display();
-                    new Notice('Tool usage statistics reset');
-                }));
+    new Setting(containerEl)
+      .setName("Require Authentication")
+      .setDesc(
+        "Require Bearer token for all connections. Disable for easier local development.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.requireAuth)
+          .onChange(async (value) => {
+            if (!value) {
+              const confirmed = window.confirm(
+                "Disabling auth allows any local process to access your vault via the MCP server. Continue?",
+              );
+              if (!confirmed) {
+                toggle.setValue(true);
+                return;
+              }
+            }
+            this.plugin.settings.requireAuth = value;
+            await this.plugin.saveSettings();
+            this.display();
+            this.plugin.restartServer();
+          }),
+      );
+
+    if (this.plugin.settings.requireAuth) {
+      new Setting(containerEl)
+        .setName("Auth Token")
+        .setDesc(
+          "Required for connecting. Use the Authorization header: Bearer <token>",
+        )
+        .addText((text) =>
+          text.setValue(this.plugin.settings.authToken).setDisabled(true),
+        )
+        .addExtraButton((btn) =>
+          btn.setIcon("copy").onClick(() => {
+            navigator.clipboard.writeText(this.plugin.settings.authToken);
+            new Notice("Token copied");
+          }),
+        );
+
+      new Setting(containerEl).setName("Regenerate Token").addButton((btn) =>
+        btn
+          .setButtonText("Regenerate")
+          .setWarning()
+          .onClick(async () => {
+            this.plugin.settings.authToken = crypto
+              .randomBytes(16)
+              .toString("hex");
+            await this.plugin.saveSettings();
+            this.display();
+            this.plugin.restartServer();
+          }),
+      );
     }
+
+    new Setting(containerEl)
+      .setName("Access Control: Blacklist")
+      .setDesc(
+        'One rule per line. Paths: "Secret/" blocks folders/files. Tags: "#secret" blocks files with that tag.',
+      )
+      .addTextArea((text) =>
+        text
+          .setPlaceholder("Secret/\n#private")
+          .setValue(this.plugin.settings.blacklist)
+          .onChange(async (value) => {
+            this.plugin.settings.blacklist = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    // --- Agent Instructions Section ---
+    containerEl.createEl("h3", { text: "Agent Instructions" });
+
+    new Setting(containerEl)
+      .setName("Enable Instructions")
+      .setDesc(
+        "Send vault context and usage guidelines to AI agents on connect. Server restarts on change.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.enableInstructions)
+          .onChange(async (value) => {
+            this.plugin.settings.enableInstructions = value;
+            await this.plugin.saveSettings();
+            this.plugin.restartServer();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Include Vault Structure")
+      .setDesc("Include top-level folder names in instructions.")
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.includeVaultStructure)
+          .onChange(async (value) => {
+            this.plugin.settings.includeVaultStructure = value;
+            await this.plugin.saveSettings();
+            this.plugin.restartServer();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Custom Instructions")
+      .setDesc(
+        "Additional instructions appended to the agent context. Server restarts on change.",
+      )
+      .addTextArea((text) =>
+        text
+          .setPlaceholder(
+            "e.g., Always use #project tag when creating notes...",
+          )
+          .setValue(this.plugin.settings.customInstructions)
+          .onChange(async (value) => {
+            this.plugin.settings.customInstructions = value;
+            await this.plugin.saveSettings();
+            this.plugin.restartServer();
+          }),
+      );
+
+    // --- Prompts Section ---
+    containerEl.createEl("h3", { text: "Format Guides (Prompts)" });
+
+    new Setting(containerEl)
+      .setName("Enable Prompts")
+      .setDesc(
+        "Expose Obsidian format reference guides as MCP prompts. Server restarts on change.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.enablePrompts)
+          .onChange(async (value) => {
+            this.plugin.settings.enablePrompts = value;
+            await this.plugin.saveSettings();
+            this.plugin.restartServer();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Obsidian Markdown Guide")
+      .setDesc("Wikilinks, embeds, callouts, frontmatter, tags.")
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.enableMarkdownGuide)
+          .onChange(async (value) => {
+            this.plugin.settings.enableMarkdownGuide = value;
+            await this.plugin.saveSettings();
+            this.plugin.restartServer();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("JSON Canvas Guide")
+      .setDesc(".canvas file format reference.")
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.enableCanvasGuide)
+          .onChange(async (value) => {
+            this.plugin.settings.enableCanvasGuide = value;
+            await this.plugin.saveSettings();
+            this.plugin.restartServer();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Obsidian Bases Guide")
+      .setDesc(".base file format reference.")
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.enableBasesGuide)
+          .onChange(async (value) => {
+            this.plugin.settings.enableBasesGuide = value;
+            await this.plugin.saveSettings();
+            this.plugin.restartServer();
+          }),
+      );
+
+    // --- Resources Section ---
+    containerEl.createEl("h3", { text: "Resources" });
+
+    new Setting(containerEl)
+      .setName("Enable Resources")
+      .setDesc(
+        "Expose vault content as MCP resources (notes, tags, folders, daily notes). Server restarts on change.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.enableResources)
+          .onChange(async (value) => {
+            this.plugin.settings.enableResources = value;
+            await this.plugin.saveSettings();
+            this.plugin.restartServer();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Enable Resource Subscriptions")
+      .setDesc(
+        "Notify connected AI agents when vault files change. Requires plugin restart.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.enableResourceSubscriptions)
+          .onChange(async (value) => {
+            this.plugin.settings.enableResourceSubscriptions = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Max Resources Listed")
+      .setDesc(
+        "Maximum number of resources returned in list operations (1-5000).",
+      )
+      .addText((text) =>
+        text
+          .setValue(String(this.plugin.settings.maxResourcesListed))
+          .onChange(async (value) => {
+            const num = parseInt(value, 10);
+            if (isNaN(num) || num < 1 || num > 5000) return;
+            this.plugin.settings.maxResourcesListed = num;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    // --- Smart Features Section ---
+    containerEl.createEl("h3", { text: "Smart Features" });
+
+    new Setting(containerEl)
+      .setName("Smart Annotations")
+      .setDesc(
+        "Add contextual hints to read_note/get_active_file responses (draft status, large note warnings, broken links).",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.enableSmartAnnotations)
+          .onChange(async (value) => {
+            this.plugin.settings.enableSmartAnnotations = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    // --- Sessions Section ---
+    this.renderSessionsSection(containerEl);
+
+    // --- Stats Section ---
+    this.renderStatsSection(containerEl);
+  }
+
+  private renderSessionsSection(containerEl: HTMLElement): void {
+    containerEl.createEl("h3", { text: "Active Sessions" });
+
+    const summaries = this.plugin.mcpServer.getSessionSummaries();
+
+    if (summaries.length === 0) {
+      containerEl.createEl("p", {
+        text: "No active sessions.",
+        cls: "mcp-stats-empty",
+      });
+      return;
+    }
+
+    const table = containerEl.createEl("table", { cls: "mcp-stats-table" });
+    const thead = table.createEl("thead");
+    const headerRow = thead.createEl("tr");
+    headerRow.createEl("th", { text: "Client" });
+    headerRow.createEl("th", { text: "Session ID" });
+    headerRow.createEl("th", { text: "Connected" });
+    headerRow.createEl("th", { text: "Last Active" });
+    headerRow.createEl("th", { text: "Tool Calls" });
+
+    const tbody = table.createEl("tbody");
+    for (const s of summaries) {
+      const row = tbody.createEl("tr");
+      const clientLabel = s.clientVersion
+        ? `${s.clientName} (${s.clientVersion})`
+        : s.clientName;
+      row.createEl("td", { text: clientLabel });
+      row.createEl("td", { text: `...${s.sessionId}` });
+      row.createEl("td", { text: this.formatRelativeTime(s.connectedAt) });
+      row.createEl("td", { text: this.formatRelativeTime(s.lastActiveAt) });
+      row.createEl("td", { text: String(s.toolCalls.total) });
+    }
+  }
+
+  private formatRelativeTime(isoString: string): string {
+    const time = new Date(isoString).getTime();
+    if (isNaN(time)) return "unknown";
+    const seconds = Math.max(0, Math.floor((Date.now() - time) / 1000));
+    if (seconds < 60) return `${seconds}s ago`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    return `${hours}h ago`;
+  }
+
+  private renderStatsSection(containerEl: HTMLElement): void {
+    containerEl.createEl("h3", { text: "Tool Usage Statistics" });
+
+    const stats = this.plugin.toolStats;
+    const toolNames = Object.keys(stats);
+
+    if (toolNames.length === 0) {
+      containerEl.createEl("p", {
+        text: "No tool usage recorded yet.",
+        cls: "mcp-stats-empty",
+      });
+    } else {
+      const table = containerEl.createEl("table", { cls: "mcp-stats-table" });
+      const thead = table.createEl("thead");
+      const headerRow = thead.createEl("tr");
+      headerRow.createEl("th", { text: "Tool" });
+      headerRow.createEl("th", { text: "Total" });
+      headerRow.createEl("th", { text: "Successful" });
+      headerRow.createEl("th", { text: "Failed" });
+
+      const tbody = table.createEl("tbody");
+      for (const name of toolNames.sort()) {
+        const s = stats[name];
+        const row = tbody.createEl("tr");
+        row.createEl("td", { text: name });
+        row.createEl("td", { text: String(s.total) });
+        row.createEl("td", { text: String(s.successful) });
+        row.createEl("td", { text: String(s.failed) });
+      }
+    }
+
+    new Setting(containerEl)
+      .setName("Reset Statistics")
+      .setDesc("Clear all tool usage statistics.")
+      .addButton((btn) =>
+        btn
+          .setButtonText("Reset")
+          .setWarning()
+          .onClick(async () => {
+            await this.plugin.resetStats();
+            this.display();
+            new Notice("Tool usage statistics reset");
+          }),
+      );
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,117 +1,118 @@
-
 export interface McpPluginSettings {
-    port: number;
-    authToken: string;
-    requireAuth: boolean;
-    blacklist: string;
-    // Phase 1: Instructions
-    enableInstructions: boolean;
-    customInstructions: string;
-    includeVaultStructure: boolean;
-    // Phase 2: Prompts
-    enablePrompts: boolean;
-    enableMarkdownGuide: boolean;
-    enableCanvasGuide: boolean;
-    enableBasesGuide: boolean;
-    // Phase 3: Resources
-    enableResources: boolean;
-    enableResourceSubscriptions: boolean;
-    maxResourcesListed: number;
-    // Phase 4: Annotations
-    enableSmartAnnotations: boolean;
+  port: number;
+  listenAddress: string;
+  authToken: string;
+  requireAuth: boolean;
+  blacklist: string;
+  // Phase 1: Instructions
+  enableInstructions: boolean;
+  customInstructions: string;
+  includeVaultStructure: boolean;
+  // Phase 2: Prompts
+  enablePrompts: boolean;
+  enableMarkdownGuide: boolean;
+  enableCanvasGuide: boolean;
+  enableBasesGuide: boolean;
+  // Phase 3: Resources
+  enableResources: boolean;
+  enableResourceSubscriptions: boolean;
+  maxResourcesListed: number;
+  // Phase 4: Annotations
+  enableSmartAnnotations: boolean;
 }
 
 export const DEFAULT_SETTINGS: McpPluginSettings = {
-    port: 27123,
-    authToken: '',
-    requireAuth: true,
-    blacklist: 'Secret/\n#secret',
-    enableInstructions: true,
-    customInstructions: '',
-    includeVaultStructure: true,
-    enablePrompts: true,
-    enableMarkdownGuide: true,
-    enableCanvasGuide: true,
-    enableBasesGuide: true,
-    enableResources: true,
-    enableResourceSubscriptions: true,
-    maxResourcesListed: 500,
-    enableSmartAnnotations: true,
+  port: 27123,
+  listenAddress: "127.0.0.1",
+  authToken: "",
+  requireAuth: true,
+  blacklist: "Secret/\n#secret",
+  enableInstructions: true,
+  customInstructions: "",
+  includeVaultStructure: true,
+  enablePrompts: true,
+  enableMarkdownGuide: true,
+  enableCanvasGuide: true,
+  enableBasesGuide: true,
+  enableResources: true,
+  enableResourceSubscriptions: true,
+  maxResourcesListed: 500,
+  enableSmartAnnotations: true,
 };
 
 export interface ToolCallStats {
-    total: number;
-    successful: number;
-    failed: number;
+  total: number;
+  successful: number;
+  failed: number;
 }
 
 export type ToolUsageStats = Record<string, ToolCallStats>;
 
 export interface McpPluginData {
-    settings: McpPluginSettings;
-    toolStats: ToolUsageStats;
+  settings: McpPluginSettings;
+  toolStats: ToolUsageStats;
 }
 
 export const DEFAULT_DATA: McpPluginData = {
-    settings: { ...DEFAULT_SETTINGS },
-    toolStats: {},
+  settings: { ...DEFAULT_SETTINGS },
+  toolStats: {},
 };
 
 export interface FileInfo {
-    name: string;
-    path: string;
-    type: 'file' | 'folder';
+  name: string;
+  path: string;
+  type: "file" | "folder";
 }
 
 export interface SearchResult {
-    path: string;
-    mtime: string;
-    tags: string[];
+  path: string;
+  mtime: string;
+  tags: string[];
 }
 
 export interface ActiveFileResult {
-    path: string;
-    frontmatter: Record<string, unknown>;
-    content: string;
+  path: string;
+  frontmatter: Record<string, unknown>;
+  content: string;
 }
 
 export interface VaultOverview {
-    name: string;
-    fileCount: number;
-    folderCount: number;
-    totalSizeBytes: number;
-    fileTypes: Record<string, number>;
-    tagCount: number;
+  name: string;
+  fileCount: number;
+  folderCount: number;
+  totalSizeBytes: number;
+  fileTypes: Record<string, number>;
+  tagCount: number;
 }
 
 export interface NoteMetadata {
-    path: string;
-    name: string;
-    createdAt: string;
-    modifiedAt: string;
-    sizeBytes: number;
-    frontmatter: Record<string, unknown>;
-    tags: string[];
-    headings: Array<{ level: number; heading: string }>;
-    links: string[];
+  path: string;
+  name: string;
+  createdAt: string;
+  modifiedAt: string;
+  sizeBytes: number;
+  frontmatter: Record<string, unknown>;
+  tags: string[];
+  headings: Array<{ level: number; heading: string }>;
+  links: string[];
 }
 
 export interface ContentSearchResult {
-    path: string;
-    matches: Array<{ line: number; text: string }>;
+  path: string;
+  matches: Array<{ line: number; text: string }>;
 }
 
 export interface SessionSummary {
-    sessionId: string;
-    clientName: string;
-    clientVersion: string;
-    connectedAt: string;
-    lastActiveAt: string;
-    durationSeconds: number;
-    toolCalls: {
-        total: number;
-        successful: number;
-        failed: number;
-        byTool: ToolUsageStats;
-    };
+  sessionId: string;
+  clientName: string;
+  clientVersion: string;
+  connectedAt: string;
+  lastActiveAt: string;
+  durationSeconds: number;
+  toolCalls: {
+    total: number;
+    successful: number;
+    failed: number;
+    byTool: ToolUsageStats;
+  };
 }


### PR DESCRIPTION
## Summary

- Adds a `listenAddress` setting (`127.0.0.1` default, `0.0.0.0` option) so AI agents in containers or remote environments can reach the server over LAN
- Dropdown in settings UI with confirmation dialog when selecting `0.0.0.0` (warns about LAN exposure)
- Startup Notice shows bound address (`0.0.0.0:PORT`) when listening on all interfaces
- Input validation in `loadSettings()` resets invalid persisted values to the safe default

## Files changed

| File | Change |
|------|--------|
| `src/types.ts` | Add `listenAddress` to settings interface + defaults |
| `src/server.ts` | Use setting instead of hardcoded `127.0.0.1` |
| `src/settings.ts` | Add Listen Address dropdown with security confirmation |
| `src/main.ts` | Add validation for persisted listen address |

## Test plan

- [x] `pnpm run build` passes
- [x] All 131 tests pass
- [ ] Manual: verify default `127.0.0.1` behavior unchanged
- [ ] Manual: switch to `0.0.0.0`, confirm dialog appears, server restarts and is reachable from another device on LAN
- [ ] Manual: verify startup Notice shows `0.0.0.0:PORT` when bound to all interfaces
- [ ] Verify existing settings without `listenAddress` migrate cleanly (defaults to `127.0.0.1`)

Closes #51